### PR TITLE
Nand read 범위 밖의 LBA값 exception 처리 및 리턴 타입 string으로 수정

### DIFF
--- a/SSD/nand_flash_memory.h
+++ b/SSD/nand_flash_memory.h
@@ -5,6 +5,6 @@ using std::string;
 
 class NandFlashMemory {
 public:
-	virtual int read(int LBA) = 0;
+	virtual string read(int LBA) = 0;
 	virtual string write(int lba, int data) = 0;
 };

--- a/SSD/nand_flash_memory_mock.h
+++ b/SSD/nand_flash_memory_mock.h
@@ -3,8 +3,8 @@
 #include "gmock/gmock.h"
 #include "nand_flash_memory.h"
 
-class NandFlashMemoryMock: public NandFlashMemory {
+class NandFlashMemoryMock : public NandFlashMemory {
 public:
-	MOCK_METHOD(int, read, (int LBA), (override));
+	MOCK_METHOD(string, read, (int LBA), (override));
 	MOCK_METHOD(string, write, (int, int), (override));
 };

--- a/SSD/nand_reader.cpp
+++ b/SSD/nand_reader.cpp
@@ -1,6 +1,7 @@
 #include "nand_reader.h"
-
+#include <stdexcept>
 int NandReader::read(int LBA)
 {
+	if (LBA < 0 || LBA >= 100) throw std::range_error("LBA 값은 0과 99 사이의 값이어야 합니다.\n");
 	return nandFlashMemory->read(LBA);
 }

--- a/SSD/nand_reader.cpp
+++ b/SSD/nand_reader.cpp
@@ -1,6 +1,6 @@
 #include "nand_reader.h"
 #include <stdexcept>
-int NandReader::read(int LBA)
+string NandReader::read(int LBA)
 {
 	if (LBA < 0 || LBA >= 100) throw std::range_error("LBA 값은 0과 99 사이의 값이어야 합니다.\n");
 	return nandFlashMemory->read(LBA);

--- a/SSD/nand_reader.cpp
+++ b/SSD/nand_reader.cpp
@@ -2,6 +2,6 @@
 #include <stdexcept>
 string NandReader::read(int LBA)
 {
-	if (LBA < 0 || LBA >= 100) throw std::range_error("LBA 값은 0과 99 사이의 값이어야 합니다.\n");
+	if (LBA < 0 || LBA >= 100) throw std::range_error("The LBA must be a value between 0 and 99.\n");
 	return nandFlashMemory->read(LBA);
 }

--- a/SSD/nand_reader.h
+++ b/SSD/nand_reader.h
@@ -1,11 +1,14 @@
 #pragma once
 
+#include <string>
 #include "nand_flash_memory.h"
+
+using std::string;
 class NandReader {
 public:
 	NandReader(NandFlashMemory* nandFlashMemory) : nandFlashMemory{ nandFlashMemory } {}
 
-	int read(int LBA);
+	string read(int LBA);
 private:
 	NandFlashMemory* nandFlashMemory;
 };

--- a/SSD/nand_reader_test.cpp
+++ b/SSD/nand_reader_test.cpp
@@ -7,7 +7,8 @@ using namespace testing;
 class NandReaderFixture : public Test {
 public:
 	static constexpr int LBA_IN_RANGE = 10;
-	static constexpr int LBA_OUT_RANGE = 105;
+	static constexpr int LBA_OVER_99 = 105;
+	static constexpr int LBA_UNDER_0 = -1;
 	const string NAND_WRITTEN_VALUE = string{ "0x12345678" };
 
 	NandFlashMemoryMock memory;
@@ -23,5 +24,6 @@ TEST_F(NandReaderFixture, readTestWithSuccessResult) {
 };
 
 TEST_F(NandReaderFixture, readTestWithOutRangedLBA) {
-	EXPECT_THROW(nand_reader.read(LBA_OUT_RANGE), std::runtime_error);
+	EXPECT_THROW(nand_reader.read(LBA_OVER_99), std::runtime_error);
+	EXPECT_THROW(nand_reader.read(LBA_UNDER_0), std::runtime_error);
 };

--- a/SSD/nand_reader_test.cpp
+++ b/SSD/nand_reader_test.cpp
@@ -3,22 +3,24 @@
 #include "nand_flash_memory_mock.h"
 
 using namespace testing;
+static constexpr int LBA_IN_RANGE = 10;
+static constexpr int LBA_OUT_RANGE = 105;
+static constexpr int NAND_WRITTEN_VALUE = 0x12345678;
 
-TEST(NandReader, readTestWithSuccessResult) {
+class NandReaderFixture : public Test {
+public:
 	NandFlashMemoryMock memory;
-	NandReader nand_reader(&memory);
-	EXPECT_CALL(memory, read(_)).WillRepeatedly(Return(0x12345678));
-	int lba = 10;
-	int actual = nand_reader.read(lba);
-	int expected = 0x12345678;
+	NandReader nand_reader{ &memory };
+};
+
+TEST_F(NandReaderFixture, readTestWithSuccessResult) {
+	EXPECT_CALL(memory, read(_)).WillRepeatedly(Return(NAND_WRITTEN_VALUE));
+	int actual = nand_reader.read(LBA_IN_RANGE);
+	int expected = NAND_WRITTEN_VALUE;
+
 	EXPECT_EQ(expected, actual);
 };
 
-TEST(NandReader, readTestWithOutRangedLBA) {
-	NandFlashMemoryMock memory;
-	NandReader nand_reader(&memory);
-	EXPECT_CALL(memory, read(_)).WillRepeatedly(Return(0x12345678));
-	int lba = 105;
-
-	EXPECT_THROW(nand_reader.read(lba), std::runtime_error);
+TEST_F(NandReaderFixture, readTestWithOutRangedLBA) {
+	EXPECT_THROW(nand_reader.read(LBA_OUT_RANGE), std::runtime_error);
 };

--- a/SSD/nand_reader_test.cpp
+++ b/SSD/nand_reader_test.cpp
@@ -13,3 +13,12 @@ TEST(NandReader, readTestWithSuccessResult) {
 	int expected = 0x12345678;
 	EXPECT_EQ(expected, actual);
 };
+
+TEST(NandReader, readTestWithOutRangedLBA) {
+	NandFlashMemoryMock memory;
+	NandReader nand_reader(&memory);
+	EXPECT_CALL(memory, read(_)).WillRepeatedly(Return(0x12345678));
+	int lba = 105;
+
+	EXPECT_THROW(nand_reader.read(lba), std::runtime_error);
+};

--- a/SSD/nand_reader_test.cpp
+++ b/SSD/nand_reader_test.cpp
@@ -1,22 +1,23 @@
 #include "gmock/gmock.h"
 #include "nand_reader.h"
 #include "nand_flash_memory_mock.h"
-
+using std::string;
 using namespace testing;
-static constexpr int LBA_IN_RANGE = 10;
-static constexpr int LBA_OUT_RANGE = 105;
-static constexpr int NAND_WRITTEN_VALUE = 0x12345678;
 
 class NandReaderFixture : public Test {
 public:
+	static constexpr int LBA_IN_RANGE = 10;
+	static constexpr int LBA_OUT_RANGE = 105;
+	const string NAND_WRITTEN_VALUE = string{ "0x12345678" };
+
 	NandFlashMemoryMock memory;
 	NandReader nand_reader{ &memory };
 };
 
 TEST_F(NandReaderFixture, readTestWithSuccessResult) {
 	EXPECT_CALL(memory, read(_)).WillRepeatedly(Return(NAND_WRITTEN_VALUE));
-	int actual = nand_reader.read(LBA_IN_RANGE);
-	int expected = NAND_WRITTEN_VALUE;
+	string actual = nand_reader.read(LBA_IN_RANGE);
+	string expected = NAND_WRITTEN_VALUE;
 
 	EXPECT_EQ(expected, actual);
 };


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용 
1.  LBA 가 범위 밖일 때 exception이 나도록 구현했습니다.
2.  read type 을 int -> string으로 수정했습니다.
3.  test fixture 도입했습니다.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
