### PR TITLE
Command Runner 구현

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -127,6 +127,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="command_runner.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="test_with_mock.cpp" />
   </ItemGroup>
@@ -134,6 +135,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="command_runner.h" />
     <ClInclude Include="storage.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -136,7 +136,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="command_runner.h" />
-    <ClInclude Include="storage.h" />
+    <ClInclude Include="ssd_interface.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -38,7 +38,7 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="storage.h">
+    <ClInclude Include="ssd_interface.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="command_runner.h">

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -30,12 +30,18 @@
     <ClCompile Include="test_with_mock.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
+    <ClCompile Include="command_runner.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="storage.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="command_runner.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TestShell/command_runner.cpp
+++ b/TestShell/command_runner.cpp
@@ -1,6 +1,10 @@
 #include "command_runner.h"
-
+#include <stdexcept>
 string CommandRunner::runCommand(vector<string> cmd) {
+	if (ssdInterface == nullptr) {
+		throw std::runtime_error("ssd Interface hasn't set");
+	}
+
 	string result = "";
 	if (cmd[1] == "R") {
 		result = ssdInterface->read(stoi(cmd[2]));

--- a/TestShell/command_runner.cpp
+++ b/TestShell/command_runner.cpp
@@ -1,0 +1,19 @@
+#include "command_runner.h"
+
+CommandRunner::CommandRunner(Storage* storage)
+	: storage(storage)
+{
+}
+
+string CommandRunner::runCommand(vector<string> cmd) {
+	string result = "";
+	if (cmd[1] == "R") {
+		result = storage->read(stoi(cmd[2]));
+	}
+	else if (cmd[1] == "W") {
+		result = storage->write(stoi(cmd[2]), stoi(cmd[3]));
+	}
+
+	return result;
+}
+

--- a/TestShell/command_runner.cpp
+++ b/TestShell/command_runner.cpp
@@ -1,9 +1,6 @@
 #include "command_runner.h"
 
-CommandRunner::CommandRunner(Storage* storage)
-	: storage(storage)
-{
-}
+
 
 string CommandRunner::runCommand(vector<string> cmd) {
 	string result = "";
@@ -15,5 +12,10 @@ string CommandRunner::runCommand(vector<string> cmd) {
 	}
 
 	return result;
+}
+
+void CommandRunner::setStorage(Storage* storage)
+{
+	this->storage = storage;
 }
 

--- a/TestShell/command_runner.cpp
+++ b/TestShell/command_runner.cpp
@@ -1,21 +1,19 @@
 #include "command_runner.h"
 
-
-
 string CommandRunner::runCommand(vector<string> cmd) {
 	string result = "";
 	if (cmd[1] == "R") {
-		result = storage->read(stoi(cmd[2]));
+		result = ssdInterface->read(stoi(cmd[2]));
 	}
 	else if (cmd[1] == "W") {
-		result = storage->write(stoi(cmd[2]), stoi(cmd[3]));
+		result = ssdInterface->write(stoi(cmd[2]), stoi(cmd[3]));
 	}
 
 	return result;
 }
 
-void CommandRunner::setStorage(Storage* storage)
+void CommandRunner::setStorage(SsdInterface* ssdInterface)
 {
-	this->storage = storage;
+	this->ssdInterface = ssdInterface;
 }
 

--- a/TestShell/command_runner.h
+++ b/TestShell/command_runner.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "storage.h"
+#include <vector>
+
+using std::string;
+using std::vector;
+
+class CommandRunner {
+public:
+	CommandRunner(Storage* storage);
+
+	string runCommand(vector<string> cmd);
+private:
+	Storage* storage;
+};

--- a/TestShell/command_runner.h
+++ b/TestShell/command_runner.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "storage.h"
+#include "ssd_interface.h"
 #include <vector>
 
 using std::string;
@@ -9,7 +9,7 @@ class CommandRunner {
 public:
 	string runCommand(vector<string> cmd);
 
-	void setStorage(Storage* storage);
+	void setStorage(SsdInterface* ssdInterface);
 private:
-	Storage* storage;
+	SsdInterface* ssdInterface;
 };

--- a/TestShell/command_runner.h
+++ b/TestShell/command_runner.h
@@ -11,5 +11,5 @@ public:
 
 	void setStorage(SsdInterface* ssdInterface);
 private:
-	SsdInterface* ssdInterface;
+	SsdInterface* ssdInterface = nullptr;
 };

--- a/TestShell/command_runner.h
+++ b/TestShell/command_runner.h
@@ -7,9 +7,9 @@ using std::vector;
 
 class CommandRunner {
 public:
-	CommandRunner(Storage* storage);
-
 	string runCommand(vector<string> cmd);
+
+	void setStorage(Storage* storage);
 private:
 	Storage* storage;
 };

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -4,7 +4,7 @@
 using std::string;
 #define interface struct
 
-interface Storage{
+interface SsdInterface{
     virtual string read(int index) = 0;
     virtual string write(int index, int data) = 0;
 };

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "storage.h"
 #include <string>
+#include "command_runner.h"
 
 using std::string;
 using namespace testing;
@@ -59,4 +60,30 @@ TEST(SSD, WriteSuccess) {
 		.WillRepeatedly(Return(""));
 
 	EXPECT_EQ(string(expected), string(mock.write(4, 0xFFFF)));
+}
+
+TEST(TestShell, CmdRunnerRead) {
+	MockStorage mock;
+	CommandRunner runner{&mock};
+
+	vector<string> command = { "\SSD.exe", "R", "1" };
+
+	EXPECT_CALL(mock, read)
+		.Times(1)
+		.WillRepeatedly(Return("0x0000FFFF"));
+	
+	EXPECT_EQ("0x0000FFFF", runner.runCommand(command));
+}
+
+TEST(TestShell, CmdRunnerWrite) {
+	MockStorage mock;
+	CommandRunner runner{ &mock };
+
+	vector<string> command = { "\SSD.exe", "W", "2", "0xAAAABBBB"};
+
+	EXPECT_CALL(mock, write)
+		.Times(1)
+		.WillRepeatedly(Return(""));
+
+	EXPECT_EQ("", runner.runCommand(command));
 }

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -20,49 +20,7 @@ protected:
 public:
 	MockStorage mockStorage;
 	CommandRunner runner;
-	
 };
-
-TEST_F(TestShellFixtureWithMock, ReadMock) {
-	int LBA = 99;
-	string expected = "0xFFFFFFFF";
-	EXPECT_CALL(mockStorage, read)
-		.WillOnce(Return(expected));
-
-	string actual = mockStorage.read(LBA);
-
-	EXPECT_EQ(expected, actual);
-}
-
-TEST_F(TestShellFixtureWithMock, ReadFailMock) {
-	int LBA = 100;
-	string expected = "ERROR";
-	EXPECT_CALL(mockStorage, read)
-		.WillOnce(Return(expected));
-
-	string actual = mockStorage.read(LBA);
-
-	EXPECT_EQ(expected, actual);
-}
-
-TEST_F(TestShellFixtureWithMock, WriteExceedIndex) {
-	string expected = "ERROR";
-	EXPECT_CALL(mockStorage, write(Ge(100), _))
-		.WillRepeatedly(Return("ERROR"));
-	EXPECT_CALL(mockStorage, write(Le(-1), _))
-		.WillRepeatedly(Return("ERROR"));
-
-	EXPECT_EQ(string(expected), string(mockStorage.write(100, 0xFFFF)));
-	EXPECT_EQ(string(expected), string(mockStorage.write(-1, 0xFFFF)));
-}
-
-TEST_F(TestShellFixtureWithMock, WriteSuccess) {
-	string expected = "";
-	EXPECT_CALL(mockStorage, write(Le(99), _))
-		.WillRepeatedly(Return(""));
-
-	EXPECT_EQ(string(expected), string(mockStorage.write(4, 0xFFFF)));
-}
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerRead) {
 	vector<string> command = { "\SSD.exe", "R", "1" };

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -1,12 +1,12 @@
 #include "gmock/gmock.h"
-#include "storage.h"
+#include "ssd_interface.h"
 #include <string>
 #include "command_runner.h"
 
 using std::string;
 using namespace testing;
 
-class MockStorage : public Storage {
+class SsdInterfaceMock : public SsdInterface {
 public:
 	MOCK_METHOD(string, read, (int), (override));
 	MOCK_METHOD(string, write, (int, int), (override));
@@ -18,7 +18,7 @@ protected:
 		runner.setStorage(&mockStorage);
 	}
 public:
-	MockStorage mockStorage;
+	SsdInterfaceMock mockStorage;
 	CommandRunner runner;
 };
 

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -61,3 +61,10 @@ TEST_F(TestShellFixtureWithMock, CmdRunnerWriteFail) {
 
 	EXPECT_EQ("ERROR", runner.runCommand(command));
 }
+
+TEST_F(TestShellFixtureWithMock, CmdRunnerNoSetInterface) {
+	CommandRunner emptyRunner;
+	vector<string> command = { "\SSD.exe", "R", "1" };
+
+	EXPECT_THROW(emptyRunner.runCommand(command), std::runtime_error);
+}

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -12,76 +12,72 @@ public:
 	MOCK_METHOD(string, write, (int, int), (override));
 };
 
+class TestShellFixtureWithMock : public Test {
+protected:
+	void SetUp() {
+		runner.setStorage(&mockStorage);
+	}
+public:
+	MockStorage mockStorage;
+	CommandRunner runner;
+	
+};
 
-TEST(TestShell, ReadMock) {
-	int LBA = 30;
-	string expected = "0x12341234";
-
-	MockStorage storage;
-	EXPECT_CALL(storage, read)
+TEST_F(TestShellFixtureWithMock, ReadMock) {
+	int LBA = 99;
+	string expected = "0xFFFFFFFF";
+	EXPECT_CALL(mockStorage, read)
 		.WillOnce(Return(expected));
 
-	string actual = storage.read(LBA);
+	string actual = mockStorage.read(LBA);
 
 	EXPECT_EQ(expected, actual);
 }
 
-TEST(TestShell, ReadFailMock) {
+TEST_F(TestShellFixtureWithMock, ReadFailMock) {
 	int LBA = 100;
 	string expected = "ERROR";
-
-	MockStorage storage;
-	EXPECT_CALL(storage, read)
+	EXPECT_CALL(mockStorage, read)
 		.WillOnce(Return(expected));
 
-	string actual = storage.read(LBA);
+	string actual = mockStorage.read(LBA);
 
 	EXPECT_EQ(expected, actual);
 }
 
-TEST(SSD, WriteExceedIndex) {
-	MockStorage mock;
-
+TEST_F(TestShellFixtureWithMock, WriteExceedIndex) {
 	string expected = "ERROR";
-	EXPECT_CALL(mock, write(Ge(100), _))
+	EXPECT_CALL(mockStorage, write(Ge(100), _))
 		.WillRepeatedly(Return("ERROR"));
-	EXPECT_CALL(mock, write(Le(-1), _))
+	EXPECT_CALL(mockStorage, write(Le(-1), _))
 		.WillRepeatedly(Return("ERROR"));
 
-	EXPECT_EQ(string(expected), string(mock.write(100, 0xFFFF)));
-	EXPECT_EQ(string(expected), string(mock.write(-1, 0xFFFF)));
+	EXPECT_EQ(string(expected), string(mockStorage.write(100, 0xFFFF)));
+	EXPECT_EQ(string(expected), string(mockStorage.write(-1, 0xFFFF)));
 }
 
-TEST(SSD, WriteSuccess) {
-	MockStorage mock;
-
+TEST_F(TestShellFixtureWithMock, WriteSuccess) {
 	string expected = "";
-	EXPECT_CALL(mock, write(Le(99), _))
+	EXPECT_CALL(mockStorage, write(Le(99), _))
 		.WillRepeatedly(Return(""));
 
-	EXPECT_EQ(string(expected), string(mock.write(4, 0xFFFF)));
+	EXPECT_EQ(string(expected), string(mockStorage.write(4, 0xFFFF)));
 }
 
-TEST(TestShell, CmdRunnerRead) {
-	MockStorage mock;
-	CommandRunner runner{&mock};
-
+TEST_F(TestShellFixtureWithMock, CmdRunnerRead) {
 	vector<string> command = { "\SSD.exe", "R", "1" };
 
-	EXPECT_CALL(mock, read)
+	EXPECT_CALL(mockStorage, read)
 		.Times(1)
 		.WillRepeatedly(Return("0x0000FFFF"));
 	
 	EXPECT_EQ("0x0000FFFF", runner.runCommand(command));
 }
 
-TEST(TestShell, CmdRunnerWrite) {
-	MockStorage mock;
-	CommandRunner runner{ &mock };
-
+TEST_F(TestShellFixtureWithMock, CmdRunnerWrite) {
 	vector<string> command = { "\SSD.exe", "W", "2", "0xAAAABBBB"};
 
-	EXPECT_CALL(mock, write)
+	EXPECT_CALL(mockStorage, write)
 		.Times(1)
 		.WillRepeatedly(Return(""));
 

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -41,3 +41,23 @@ TEST_F(TestShellFixtureWithMock, CmdRunnerWrite) {
 
 	EXPECT_EQ("", runner.runCommand(command));
 }
+
+TEST_F(TestShellFixtureWithMock, CmdRunnerReadFail) {
+	vector<string> command = { "\SSD.exe", "R", "110" };
+
+	EXPECT_CALL(mockStorage, read)
+		.Times(1)
+		.WillRepeatedly(Return("ERROR"));
+
+	EXPECT_EQ("ERROR", runner.runCommand(command));
+}
+
+TEST_F(TestShellFixtureWithMock, CmdRunnerWriteFail) {
+	vector<string> command = { "\SSD.exe", "W", "110", "0xFFFFFFFF"};
+
+	EXPECT_CALL(mockStorage, write)
+		.Times(1)
+		.WillRepeatedly(Return("ERROR"));
+
+	EXPECT_EQ("ERROR", runner.runCommand(command));
+}


### PR DESCRIPTION
패치 내용
- Command Runner 구현
패치 세부 내용
1. User 에게 받은 Command 를 SSD.exe 를 통해 실행하는 CommandRunner 구현 입니다 (현재는 Mock Interface)
2. 현재는 command를 string 으로 받아, Read/Write 하는 부분이 구현되었습니다.
3. Storage -> SsdInterface 로 이름을 변경하였습니다. (구현체는 SsdImpl 로 구현할 예정)
4. Read/Write, Read/Write fail, interface 없을 시 Exception 하는 구현과 TC 가 추가되었습니다.
5. Test Fixture 도입하였습니다.
6. 기존에 Storage 를 직접 이용하는 TC 는 필요없을거라 판단되어 삭제하였습니다.

이 부분은 중점적으로 봐주세요
- Exception 은 추후에 따로 구현할까 하는데, 지금처럼 runtime_exception 에 string 으로 구분하는것이 나을지 의견 주시면 좋을 것 같습니다.

Check lists
- [ ] Ctrl + K + D 로 포매팅 확인
- [ ] Build 확인 (master branch 기준)
- [ ] Unit Test 100% 통과 확인 (master branch 기준)
- [ ] 이상한 파일이 들어가지 않았는지 확인
