### PR TITLE
Test shell/command runner read write

### DIFF
--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -30,6 +30,15 @@
     <ClCompile Include="command_parser.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="test_testshell_command_parser.cpp">
+      <Filter>테스트 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/TestShell/command_runner.cpp
+++ b/TestShell/command_runner.cpp
@@ -2,7 +2,7 @@
 #include <stdexcept>
 string CommandRunner::read(const string& LBA)
 {
-	if (ssdInterface == nullptr) {
+	if (isSetSsdInterface() == false) {
 		throw std::runtime_error("ssd Interface hasn't set");
 	}
 
@@ -13,13 +13,18 @@ string CommandRunner::read(const string& LBA)
 
 string CommandRunner::write(const string& LBA, const string& value)
 {
-	if (ssdInterface == nullptr) {
+	if (isSetSsdInterface() == false) {
 		throw std::runtime_error("ssd Interface hasn't set");
 	}
 	
 	string result = ssdInterface->write(LBA, value);
 
 	return result;
+}
+
+bool CommandRunner::isSetSsdInterface()
+{
+	return ssdInterface != nullptr;
 }
 
 void CommandRunner::setStorage(SsdInterface* ssdInterface)

--- a/TestShell/command_runner.cpp
+++ b/TestShell/command_runner.cpp
@@ -1,17 +1,23 @@
 #include "command_runner.h"
 #include <stdexcept>
-string CommandRunner::runCommand(vector<string> cmd) {
+string CommandRunner::read(const string& LBA)
+{
 	if (ssdInterface == nullptr) {
 		throw std::runtime_error("ssd Interface hasn't set");
 	}
 
-	string result = "";
-	if (cmd[1] == "R") {
-		result = ssdInterface->read(stoi(cmd[2]));
+	string result = ssdInterface->read(LBA);
+
+	return result;
+}
+
+string CommandRunner::write(const string& LBA, const string& value)
+{
+	if (ssdInterface == nullptr) {
+		throw std::runtime_error("ssd Interface hasn't set");
 	}
-	else if (cmd[1] == "W") {
-		result = ssdInterface->write(stoi(cmd[2]), stoi(cmd[3]));
-	}
+	
+	string result = ssdInterface->write(LBA, value);
 
 	return result;
 }

--- a/TestShell/command_runner.h
+++ b/TestShell/command_runner.h
@@ -7,8 +7,8 @@ using std::vector;
 
 class CommandRunner {
 public:
-	string runCommand(vector<string> cmd);
-
+	string read(const string& LBA);
+	string write(const string& LBA, const string& value);
 	void setStorage(SsdInterface* ssdInterface);
 private:
 	SsdInterface* ssdInterface = nullptr;

--- a/TestShell/command_runner.h
+++ b/TestShell/command_runner.h
@@ -9,6 +9,7 @@ class CommandRunner {
 public:
 	string read(const string& LBA);
 	string write(const string& LBA, const string& value);
+	bool isSetSsdInterface();
 	void setStorage(SsdInterface* ssdInterface);
 private:
 	SsdInterface* ssdInterface = nullptr;

--- a/TestShell/ssd_interface.h
+++ b/TestShell/ssd_interface.h
@@ -5,6 +5,6 @@ using std::string;
 #define interface struct
 
 interface SsdInterface{
-    virtual string read(int index) = 0;
-    virtual string write(int index, int data) = 0;
+    virtual string read(const string& index) = 0;
+    virtual string write(const string& index, const string& data) = 0;
 };

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -20,52 +20,47 @@ protected:
 public:
 	SsdInterfaceMock mockStorage;
 	CommandRunner runner;
+
+	const string VALID_LBA = "10";
+	const string INVALID_LBA = "1000";
+	const string TEST_VALUE = "0xAAAABBBB";
+	const string ERROR_STRING = "ERROR";
 };
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerRead) {
-	string LBA = "10";
-
-	EXPECT_CALL(mockStorage, read)
+	EXPECT_CALL(mockStorage, read(VALID_LBA))
 		.Times(1)
 		.WillRepeatedly(Return("0x0000FFFF"));
 	
-	EXPECT_EQ("0x0000FFFF", runner.read(LBA));
+	EXPECT_EQ("0x0000FFFF", runner.read(VALID_LBA));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerWrite) {
-	string LBA = "10";
-	string value = "0xAAAABBBB";
-	EXPECT_CALL(mockStorage, write(LBA, _))
+	EXPECT_CALL(mockStorage, write(VALID_LBA, _))
 		.Times(1)
-		.WillRepeatedly(Return(value));
+		.WillRepeatedly(Return(TEST_VALUE));
 
-	EXPECT_EQ(value, runner.write(LBA, value));
+	EXPECT_EQ(TEST_VALUE, runner.write(VALID_LBA, TEST_VALUE));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerReadFail) {
-	string LBA = "1000";
-
-	EXPECT_CALL(mockStorage, read)
+	EXPECT_CALL(mockStorage, read(INVALID_LBA))
 		.Times(1)
-		.WillRepeatedly(Return("ERROR"));
+		.WillRepeatedly(Return(ERROR_STRING));
 
-	EXPECT_EQ("ERROR", runner.read(LBA));
+	EXPECT_EQ(ERROR_STRING, runner.read(INVALID_LBA));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerWriteFail) {
-	string LBA = "1000";
-	string value = "0xFFFFFFFF";
-
-	EXPECT_CALL(mockStorage, write(LBA, _))
+	EXPECT_CALL(mockStorage, write(INVALID_LBA, _))
 		.Times(1)
-		.WillRepeatedly(Return("ERROR"));
+		.WillRepeatedly(Return(ERROR_STRING));
 
-	EXPECT_EQ("ERROR", runner.write(LBA, value));
+	EXPECT_EQ(ERROR_STRING, runner.write(INVALID_LBA, TEST_VALUE));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerNoSetInterface) {
 	CommandRunner emptyRunner;
-	string LBA = "10";
 
-	EXPECT_THROW(emptyRunner.read(LBA), std::runtime_error);
+	EXPECT_THROW(emptyRunner.read(VALID_LBA), std::runtime_error);
 }

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -8,8 +8,8 @@ using namespace testing;
 
 class SsdInterfaceMock : public SsdInterface {
 public:
-	MOCK_METHOD(string, read, (int), (override));
-	MOCK_METHOD(string, write, (int, int), (override));
+	MOCK_METHOD(string, read, (const string&), (override));
+	MOCK_METHOD(string, write, (const string&, const string&), (override));
 };
 
 class TestShellFixtureWithMock : public Test {
@@ -23,48 +23,49 @@ public:
 };
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerRead) {
-	vector<string> command = { "\SSD.exe", "R", "1" };
+	string LBA = "10";
 
 	EXPECT_CALL(mockStorage, read)
 		.Times(1)
 		.WillRepeatedly(Return("0x0000FFFF"));
 	
-	EXPECT_EQ("0x0000FFFF", runner.runCommand(command));
+	EXPECT_EQ("0x0000FFFF", runner.read(LBA));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerWrite) {
-	vector<string> command = { "\SSD.exe", "W", "2", "0xAAAABBBB"};
-
-	EXPECT_CALL(mockStorage, write)
+	string LBA = "10";
+	string value = "0xAAAABBBB";
+	EXPECT_CALL(mockStorage, write(LBA, _))
 		.Times(1)
-		.WillRepeatedly(Return(""));
+		.WillRepeatedly(Return(value));
 
-	EXPECT_EQ("", runner.runCommand(command));
+	EXPECT_EQ(value, runner.write(LBA, value));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerReadFail) {
-	vector<string> command = { "\SSD.exe", "R", "110" };
+	string LBA = "1000";
 
 	EXPECT_CALL(mockStorage, read)
 		.Times(1)
 		.WillRepeatedly(Return("ERROR"));
 
-	EXPECT_EQ("ERROR", runner.runCommand(command));
+	EXPECT_EQ("ERROR", runner.read(LBA));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerWriteFail) {
-	vector<string> command = { "\SSD.exe", "W", "110", "0xFFFFFFFF"};
+	string LBA = "1000";
+	string value = "0xFFFFFFFF";
 
-	EXPECT_CALL(mockStorage, write)
+	EXPECT_CALL(mockStorage, write(LBA, _))
 		.Times(1)
 		.WillRepeatedly(Return("ERROR"));
 
-	EXPECT_EQ("ERROR", runner.runCommand(command));
+	EXPECT_EQ("ERROR", runner.write(LBA, value));
 }
 
 TEST_F(TestShellFixtureWithMock, CmdRunnerNoSetInterface) {
 	CommandRunner emptyRunner;
-	vector<string> command = { "\SSD.exe", "R", "1" };
+	string LBA = "10";
 
-	EXPECT_THROW(emptyRunner.runCommand(command), std::runtime_error);
+	EXPECT_THROW(emptyRunner.read(LBA), std::runtime_error);
 }


### PR DESCRIPTION
패치 내용
- Command  실행방식에 대한 요구사항이 있어 runCommand를 read / write 로 분리하려 합니다.
패치 세부 내용
1. CommandRunner 는 SsdInterface 를 가진 상태로 read/write 의 처리를 하게 됩니다.
2. read, write 분리하였고, 추후 SSD.exe 의 command 추가 시 CommandRunner 에 기능이 추가될 예정입니다. 
3. Test Code 에 있는 리터럴들은 Fixture 내부로 이동하였습니다.

이 부분은 중점적으로 봐주세요
- @JIeunAmy 님 @dongs83  님 요청하신 부분에 대한 구현입니다. 확인 후 리뷰 부탁드립니다.

Check lists
- [ ] Ctrl + K + D 로 포매팅 확인
- [ ] Build 확인 (master branch 기준)
- [ ] Unit Test 100% 통과 확인 (master branch 기준)
- [ ] 이상한 파일이 들어가지 않았는지 확인
