### PR TITLE
Test shell/command review

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -127,6 +127,8 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+
+    <ClCompile Include="command.cpp" />
     <ClCompile Include="command_runner.cpp" />
     <ClCompile Include="command_parser.cpp" />
     <ClCompile Include="main.cpp" />
@@ -143,10 +145,13 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+
+    <ClInclude Include="command.h" />
     <ClInclude Include="command_runner.h" />
     <ClInclude Include="shell.h" />
     <ClInclude Include="ssd_interface.h" />
     <ClInclude Include="command_parser.h" />
+    <ClInclude Include="storage.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -17,6 +17,25 @@
       <UniqueIdentifier>{25fe4ce9-965b-48ea-8131-2a5d865f872f}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="소스 파일">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="헤더 파일">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="리소스 파일">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="테스트 파일">
+      <UniqueIdentifier>{25fe4ce9-965b-48ea-8131-2a5d865f872f}</UniqueIdentifier>
+    </Filter>
+  </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp">
       <Filter>소스 파일</Filter>
@@ -39,11 +58,15 @@
     <ClCompile Include="test_testshell_command_parser.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
+
+
+
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="storage.h">
     <ClInclude Include="ssd_interface.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
@@ -51,6 +74,9 @@
       <Filter>헤더 파일</Filter>
     </ClInclude>
     <ClInclude Include="command_parser.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="command.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -1,0 +1,71 @@
+#include <iostream>
+#include <string>
+#include <vector>
+#include <sstream>
+#include <stdexcept>
+
+#include "command.h"
+
+Command::Command(std::vector<std::string> commands) {
+
+	ShellCommands = commands;
+}
+
+std::vector<std::string> Command::getShellCommands(void) {
+	return ShellCommands;
+}
+
+std::string Command::getHelp(void) {
+	return help;
+}
+
+int Command::getNumOfArgs(void) {
+	return numOfArgs;
+}
+
+void ReadCommand::run(void)
+{
+}
+
+void WriteCommand::run(void)
+{
+}
+
+void ExitCommand::run(void)
+{
+}
+
+void HelpCommand::run(void)
+{
+}
+
+void FullWriteCommand::run(void)
+{
+}
+
+void FullReadCommand::run(void)
+{
+}
+
+Command* FactoryCommand::makeCommand(const std::string& cmd)
+{
+	std::istringstream ss(cmd);
+	std::string word;
+	std::vector<std::string> commands;
+	std::string shellCmd;
+
+	while (ss >> word) {
+		commands.push_back(word);
+	}
+
+	shellCmd = commands.front();
+
+	if (shellCmd == CMD_READ) return new ReadCommand(commands);
+	else if (shellCmd == CMD_WRITE) return new WriteCommand(commands);
+	else if (shellCmd == CMD_EXIT) return new ExitCommand(commands);
+	else if (shellCmd == CMD_HELP) return new HelpCommand(commands);
+	else if (shellCmd == CMD_FULLWRITE) return new FullWriteCommand(commands);
+	else if (shellCmd == CMD_FULLREAD) return new FullReadCommand(commands);
+
+	else return nullptr;
+}

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -21,43 +21,61 @@ public:
 	virtual void run(void) = 0;
 
 	std::vector<std::string> ShellCommands;
-	int numOfArgs;
-	std::string help;
+	int numOfArgs = 0;
+	std::string help = "";
 };
 
 class ReadCommand : public Command {
 public:
-	ReadCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	ReadCommand(std::vector<std::string> cmd) : Command(cmd) {
+		numOfArgs = 2;
+		help = "read [LBA]";
+	};
 	void run(void) override;
 };
 
 class WriteCommand : public Command {
 public:
-	WriteCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	WriteCommand(std::vector<std::string> cmd) : Command(cmd) {
+		numOfArgs = 3;
+		help = "write [LBA] [data]";
+	};
 	void run(void) override;
 };
 
 class ExitCommand : public Command {
 public:
-	ExitCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	ExitCommand(std::vector<std::string> cmd) : Command(cmd) {
+		numOfArgs = 1;
+		help = "exit";
+	};
 	void run(void) override;
 };
 
 class HelpCommand : public Command {
 public:
-	HelpCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	HelpCommand(std::vector<std::string> cmd) : Command(cmd) {
+		numOfArgs = 1;
+		help = "help";
+	};
 	void run(void) override;
 };
 
 class FullWriteCommand : public Command {
 public:
-	FullWriteCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	FullWriteCommand(std::vector<std::string> cmd) : Command(cmd) {
+		numOfArgs = 1;
+		help = "fullwrite";
+	};
 	void run(void) override;
 };
 
 class FullReadCommand : public Command {
 public:
-	FullReadCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	FullReadCommand(std::vector<std::string> cmd) : Command(cmd) {
+		numOfArgs = 1;
+		help = "fullread";
+	};
 	void run(void) override;
 };
 

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <iostream>
+#include <vector>
+
+namespace {
+	const std::string CMD_READ = "read";
+	const std::string CMD_WRITE = "write";
+	const std::string CMD_EXIT = "exit";
+	const std::string CMD_HELP = "help";
+	const std::string CMD_FULLWRITE = "fullwrite";
+	const std::string CMD_FULLREAD = "fullread";
+}
+
+class Command {
+public:
+	Command(std::vector<std::string> commands);
+	std::vector<std::string> getShellCommands(void);
+	std::string getHelp(void);
+	int getNumOfArgs(void);
+
+	virtual void run(void) = 0;
+
+	std::vector<std::string> ShellCommands;
+	int numOfArgs;
+	std::string help;
+};
+
+class ReadCommand : public Command {
+public:
+	ReadCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	void run(void) override;
+};
+
+class WriteCommand : public Command {
+public:
+	WriteCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	void run(void) override;
+};
+
+class ExitCommand : public Command {
+public:
+	ExitCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	void run(void) override;
+};
+
+class HelpCommand : public Command {
+public:
+	HelpCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	void run(void) override;
+};
+
+class FullWriteCommand : public Command {
+public:
+	FullWriteCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	void run(void) override;
+};
+
+class FullReadCommand : public Command {
+public:
+	FullReadCommand(std::vector<std::string> cmd) : Command(cmd) {};
+	void run(void) override;
+};
+
+class FactoryCommand {
+public:
+	Command* makeCommand(const std::string& cmd);
+};

--- a/TestShell/command_parser.cpp
+++ b/TestShell/command_parser.cpp
@@ -4,69 +4,19 @@
 #include <sstream>
 #include <stdexcept>
 #include "command_parser.h"
-
+#include "command.h"
 using std::string;
 
-std::vector<std::string> CommandParser::getCommand(const std::string& command)
+Command* CommandParser::getCommand(const std::string& command)
 {
-	//Split cmdline
-	std::vector<std::string> in;
-	std::vector<std::string> out;
-	std::istringstream ss(command);
-	std::string word;
+	FactoryCommand fc;
+	Command* cmd = fc.makeCommand(command);
 
-	while (ss >> word) {
-		in.push_back(word);
-	}
-
-	//Handle command
-	if (in[0] == "read") {
-		if (in.size() != 2) {
-			throw std::invalid_argument("Invalid argument");
-		}
-
-		int address = std::stoi(in[1]);
-		if (address < 0 || address > 99) {
-			throw std::invalid_argument("Out of range");
-		}
-		out.push_back("./ssd.exe");
-		out.push_back("R");
-		out.push_back(in[1]);
-	}
-	else if (in[0] == "write") {
-		if (in.size() != 3) {
-			throw std::invalid_argument("Invalid argument");
-		}
-
-		int address = std::stoi(in[1]);
-		if (address < 0 || address > 99) {
-			throw std::invalid_argument("Out of range");
-		}
-
-		out.push_back("./ssd.exe");
-		out.push_back("W");
-		out.push_back(in[1]);
-		out.push_back(in[2]);
-	}
-	else if (in[0] == "exit") {
-		if (in.size() != 1) {
-			throw std::invalid_argument("Invalid argument");
-		}
-
-		out.push_back(in[0]);
-	}
-	else if (in[0] == "help") {
-		if (in.size() != 1) {
-			throw std::invalid_argument("Invalid argument");
-		}
-		out.push_back(in[0]);
-
-		//print help
-		//std::cout << "read" << "address" << std::endl;
-
-	}
-	else {
+	if (cmd == nullptr)
 		throw std::invalid_argument("Invalid command");
-	}
-	return out;
+
+	if (cmd->getShellCommands().size() != cmd->getNumOfArgs())
+		throw std::invalid_argument("Invalid argument");
+
+	return cmd;
 }

--- a/TestShell/command_parser.h
+++ b/TestShell/command_parser.h
@@ -1,9 +1,9 @@
 #pragma once
 #include <iostream>
-#include <vector>
+#include "command.h"
 
 class CommandParser {
 
 public:
-	std::vector<std::string> getCommand(const std::string& command);
+	Command* getCommand(const std::string& command);
 };

--- a/TestShell/shell.cpp
+++ b/TestShell/shell.cpp
@@ -10,7 +10,7 @@ void TestShell::runShell() {
 			continue;
 
 		try {
-			command = parser.getCommand(input);
+			command = parser.getCommand(input)->getShellCommands();
 			if (command[0] == "exit")
 				return;
 			else if (command[0] == "help") {

--- a/TestShell/test_testshell_command_parser.cpp
+++ b/TestShell/test_testshell_command_parser.cpp
@@ -14,11 +14,25 @@ TEST(CommandParserTest, Read) {
 	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands());
 }
 
+TEST(CommandParserTest, ReadWithWrongArgs) {
+	CommandParser cmdParser;
+	string inputCommand = "read 0 0";
+
+	EXPECT_THROW(cmdParser.getCommand(inputCommand), std::invalid_argument);
+}
+
 TEST(CommandParserTest, Write) {
 	CommandParser cmdParser;
 	string inputCommand = "write 0 0x12341234";
 	vector<string> exepct = { "write", "0", "0x12341234"};
 	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands());
+}
+
+TEST(CommandParserTest, WriteWithWrongArgs) {
+	CommandParser cmdParser;
+	string inputCommand = "write 0 0 0";
+
+	EXPECT_THROW(cmdParser.getCommand(inputCommand), std::invalid_argument);
 }
 
 TEST(CommandParserTest, Help) {
@@ -28,6 +42,13 @@ TEST(CommandParserTest, Help) {
 	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands()[0]);
 }
 
+TEST(CommandParserTest, HelpWithWrongArgs) {
+	CommandParser cmdParser;
+	string inputCommand = "help 0";
+
+	EXPECT_THROW(cmdParser.getCommand(inputCommand), std::invalid_argument);
+}
+
 TEST(CommandParserTest, Exit) {
 	CommandParser cmdParser;
 	string inputCommand = "exit";
@@ -35,8 +56,15 @@ TEST(CommandParserTest, Exit) {
 	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands()[0]);
 }
 
+TEST(CommandParserTest, ExitWithWrongArgs) {
+	CommandParser cmdParser;
+	string inputCommand = "exit 0";
+
+	EXPECT_THROW(cmdParser.getCommand(inputCommand), std::invalid_argument);
+}
+
 TEST(CommandParserTest, InValidCommand) {
 	CommandParser cmdParser;
 	string inputCommand = "R 0";
-	EXPECT_THROW(cmdParser.getCommand(inputCommand)->getShellCommands(), std::invalid_argument);
+	EXPECT_THROW(cmdParser.getCommand(inputCommand), std::invalid_argument);
 }

--- a/TestShell/test_testshell_command_parser.cpp
+++ b/TestShell/test_testshell_command_parser.cpp
@@ -10,33 +10,33 @@ using std::vector;
 TEST(CommandParserTest, Read) {
 	CommandParser cmdParser;
 	string inputCommand = "read 0";
-	vector<string> exepct = { "./ssd.exe", "R", "0" };
-	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand));
+	vector<string> exepct = { "read", "0" };
+	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands());
 }
 
 TEST(CommandParserTest, Write) {
 	CommandParser cmdParser;
 	string inputCommand = "write 0 0x12341234";
-	vector<string> exepct = { "./ssd.exe", "W", "0", "0x12341234" };
-	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand));
+	vector<string> exepct = { "write", "0", "0x12341234"};
+	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands());
 }
 
 TEST(CommandParserTest, Help) {
 	CommandParser cmdParser;
 	string inputCommand = "help";
 	string exepct = "help";
-	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)[0]);
+	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands()[0]);
 }
 
 TEST(CommandParserTest, Exit) {
 	CommandParser cmdParser;
 	string inputCommand = "exit";
 	string exepct = "exit";
-	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)[0]);
+	EXPECT_EQ(exepct, cmdParser.getCommand(inputCommand)->getShellCommands()[0]);
 }
 
 TEST(CommandParserTest, InValidCommand) {
 	CommandParser cmdParser;
 	string inputCommand = "R 0";
-	EXPECT_THROW(cmdParser.getCommand(inputCommand), std::invalid_argument);
+	EXPECT_THROW(cmdParser.getCommand(inputCommand)->getShellCommands(), std::invalid_argument);
 }


### PR DESCRIPTION
패치 내용
Command class를 생성하였습니다. (Refac)
패치 세부 내용
1. Command class가 추가됨에 따라 이 객체를 사용하는 CommandParser, Shell 에서 함께 수정이 발생하였습니다
2. Command 는 Factory Pattern을 적용하여 User의 input command에 맞는 Command를 return하도록 구현했습니다.
3.

이 부분은 중점적으로 봐주세요
기존 vector<string> 으로 command 정보를 return 하던 것을 class 형태로 수정하였습니다.

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
