### PR TITLE
SSD Run 으로 Read 명령어 실행 구현

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -135,6 +135,7 @@
     <ClCompile Include="nand_writer.cpp" />
     <ClCompile Include="nand_writer_test.cpp" />
     <ClCompile Include="ssd.cpp" />
+    <ClCompile Include="ssd_test.cpp" />
     <None Include="packages.config" />
     <ClCompile Include="nand_reader.cpp" />
     <ClCompile Include="nand_reader_test.cpp" />

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="ssd.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="ssd_test.cpp">
+      <Filter>테스트 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/SSD/main.cpp
+++ b/SSD/main.cpp
@@ -8,13 +8,9 @@ int main(void) {
 #else
 #include "ssd.h"
 
-int main(int argc, char* argv[]) {
-	// 1. Create SSD instance
-	SSD& ssd = SSD::getInstance();
-	
-	// 2. Parsing command
-
-	// 3. Process command
-	ssd.run();
+int main(int argc, const char* argv[]) {
+	FileHandler* fileHandler = new FileHandler();
+	SSD* ssd = new SSD(fileHandler);
+	ssd->run(argc, argv);
 }
 #endif

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -1,4 +1,5 @@
 #include "ssd.h"
+#include <stdexcept>
 
 SSD::SSD(FileHandler* fileHandler) {
 	// Create result IO instance
@@ -19,20 +20,25 @@ SSD::~SSD() {
 
 void SSD::run(int argc, const char* argv[])
 {
-	argumentParser->parse_args(argc, argv);
-	string data="";
-	switch (argumentParser->getCmdType()) {
-	case ArgumentParser::READ_CMD: {
-		int addr = argumentParser->getAddr();
-		data = reader->read(addr);
-		break;
+	string data = "";
+	try {
+		argumentParser->parse_args(argc, argv);
+		switch (argumentParser->getCmdType()) {
+		case ArgumentParser::READ_CMD: {
+			int addr = argumentParser->getAddr();
+			data = reader->read(addr);
+			break;
+		}
+		case ArgumentParser::WRITE_CMD: {
+			break;
+		}
+		default: {
+			return;
+		}
+		}
 	}
-	case ArgumentParser::WRITE_CMD: {
-		break;
-	}
-	default: {
-		return;
-	}
+	catch (std::exception e) {
+		data = "ERROR";
 	}
 	outputHandler->output(data);
 }

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -1,20 +1,14 @@
 #include "ssd.h"
 
-SSD& SSD::getInstance()
-{
-	static SSD instance;
-	return instance;
-}
-
-SSD::SSD() {
-	// Create utility instance
-	FileHandler* fh = new FileHandler();
-	outputHandler = new OutputHandler(fh);
-
-	// Create IO instance
-	nand = new NandFlashMemoryImpl(fh);
+SSD::SSD(FileHandler* fileHandler) {
+	// Create result IO instance
+	outputHandler = new OutputHandler(fileHandler);
+	// Create nand IO instance
+	nand = new NandFlashMemoryImpl(fileHandler);
 	reader = new NandReader(nand);
 	writer = new NandWriter(nand);
+
+	argumentParser = new ArgumentParser();
 }
 
 SSD::~SSD() {
@@ -23,6 +17,22 @@ SSD::~SSD() {
 	delete nand;
 }
 
-void SSD::run()
+void SSD::run(int argc, const char* argv[])
 {
+	argumentParser->parse_args(argc, argv);
+	string data="";
+	switch (argumentParser->getCmdType()) {
+	case ArgumentParser::READ_CMD: {
+		int addr = argumentParser->getAddr();
+		data = reader->read(addr);
+		break;
+	}
+	case ArgumentParser::WRITE_CMD: {
+		break;
+	}
+	default: {
+		return;
+	}
+	}
+	outputHandler->output(data);
 }

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -33,6 +33,7 @@ void SSD::run(int argc, const char* argv[])
 			break;
 		}
 		default: {
+			throw std::invalid_argument("unknown type");
 			return;
 		}
 		}

--- a/SSD/ssd.h
+++ b/SSD/ssd.h
@@ -5,21 +5,19 @@
 #include "nand_flash_memory_impl.h"
 #include "OutputHandler.h"
 #include "FileHandler.h"
+#include "ArgumentParser.h"
 
 class SSD
 {
 public:
-	static SSD& getInstance();
+	SSD(FileHandler* fileHandler);
 	~SSD();
-	void run();
-
+	void run(int argc, const char* argv[]);
 private:
-	SSD();
-	SSD(const SSD& other) = delete;
-	SSD& operator=(const SSD& other) = delete;
 
 	NandReader* reader;
 	NandWriter* writer;
 	NandFlashMemory* nand;
 	OutputHandler* outputHandler;
+	ArgumentParser* argumentParser;
 };

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -5,13 +5,12 @@ using namespace testing;
 TEST(SSD, run_with_read_command)
 {
 	// arrange
-	SSD& ssd = SSD::getInstance();
 	FileHandlerMock mockedFileHandler;
-	ssd.setFileHandler(&mockedFileHandler);
-	
+	SSD ssd = SSD(&mockedFileHandler);
+
 	//1. ssd.exe r 0 호출시
-	int argc = 2;
-	const char* argv[] = { "r", "0" };
+	int argc = 3;
+	const char* argv[] = {"ssd.exe", "r", "0" };
 
 	//2. ssd_nand.txt에 아래와 같이 작성되어있다면
 	vector<string> writtenData = { "0\t0x11111111","1\t0x22222222" };

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -1,0 +1,28 @@
+#include "gmock/gmock.h"
+#include "ssd.h"
+#include "file_handler_mock.h"
+using namespace testing;
+TEST(SSD, run_with_read_command)
+{
+	// arrange
+	SSD& ssd = SSD::getInstance();
+	FileHandlerMock mockedFileHandler;
+	ssd.setFileHandler(&mockedFileHandler);
+	
+	//1. ssd.exe r 0 호출시
+	int argc = 2;
+	const char* argv[] = { "r", "0" };
+
+	//2. ssd_nand.txt에 아래와 같이 작성되어있다면
+	vector<string> writtenData = { "0\t0x11111111","1\t0x22222222" };
+	EXPECT_CALL(mockedFileHandler, read("ssd_nand.txt"))
+		.Times(1)
+		.WillRepeatedly(Return(writtenData));
+
+	//3. output에 0x11111111을 적길 기대합니다.
+	vector<string> expectedOutput = { "0x11111111" };
+	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
+		.Times(1);
+
+	ssd.run(argc, argv);
+}

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -1,4 +1,4 @@
-#include "gmock/gmock.h"
+ï»¿#include "gmock/gmock.h"
 #include "ssd.h"
 #include "file_handler_mock.h"
 using namespace testing;
@@ -6,22 +6,22 @@ using namespace testing;
 class SSDFixture : public Test {
 public:
 	FileHandlerMock mockedFileHandler;
-	SSD ssd{&mockedFileHandler};
+	SSD ssd{ &mockedFileHandler };
 
-	// mocking nand µ¥ÀÌÅÍ. 
-	// n¹øÂ° addrÀÇ °ªÀº nÀÇ 16Áø¼ö Ç¥Çö. (ex  15\t0x0000000f )
+	// mocking nand ë°ì´í„°. 
+	// në²ˆì§¸ addrì˜ ê°’ì€ nì˜ 16ì§„ìˆ˜ í‘œí˜„. (ex  15\t0x0000000f )
 	vector<string> getMockedData() {
 		vector<string> ret;
 		for (int i = 0; i < 100; i++) {
 			std::ostringstream oss;
-			// 10Áø¼ö¿Í ÅÇ
+			// 10ì§„ìˆ˜ì™€ íƒ­
 			oss << i << '\t'
-				// "0x" Á¢µÎ»ç
+				// "0x" ì ‘ë‘ì‚¬
 				<< "0x"
-				// 16Áø¼ö, ¼Ò¹®ÀÚ, Æø 8, '0' Ã¤¿ò
+				// 16ì§„ìˆ˜, ì†Œë¬¸ì, í­ 8, '0' ì±„ì›€
 				<< std::hex << std::nouppercase << std::setw(8) << std::setfill('0')
 				<< i;
-			// ´Ù½Ã 10Áø¼ö ¸ğµå·Î º¹¿ø(´ÙÀ½ ·çÇÁ¿¡¼­ ¾ÈÀüÇÏ°Ô »ç¿ëÇÏ±â À§ÇØ)
+			// ë‹¤ì‹œ 10ì§„ìˆ˜ ëª¨ë“œë¡œ ë³µì›(ë‹¤ìŒ ë£¨í”„ì—ì„œ ì•ˆì „í•˜ê²Œ ì‚¬ìš©í•˜ê¸° ìœ„í•´)
 			oss << std::dec;
 
 			ret.push_back(oss.str());
@@ -32,17 +32,17 @@ public:
 
 TEST_F(SSDFixture, run_with_read_command)
 {
-	//1. ssd.exe r 0 È£Ãâ½Ã
+	//1. ssd.exe r 0 í˜¸ì¶œì‹œ
 	int argc = 3;
-	const char* argv[] = {"ssd.exe", "r", "1" };
+	const char* argv[] = { "ssd.exe", "r", "1" };
 
-	//2. ssd_nand.txt¿¡ ¾Æ·¡¿Í °°ÀÌ ÀÛ¼ºµÇ¾îÀÖ´Ù¸é
+	//2. ssd_nand.txtì— ì•„ë˜ì™€ ê°™ì´ ì‘ì„±ë˜ì–´ìˆë‹¤ë©´
 	vector<string> writtenData = getMockedData();
 	EXPECT_CALL(mockedFileHandler, read("ssd_nand.txt"))
 		.Times(1)
 		.WillRepeatedly(Return(writtenData));
 
-	//3. output¿¡ 0x00000001À» Àû±æ ±â´ëÇÕ´Ï´Ù.
+	//3. outputì— 0x00000001ì„ ì ê¸¸ ê¸°ëŒ€í•©ë‹ˆë‹¤.
 	vector<string> expectedOutput = { "0x00000001" };
 	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
 		.Times(1);
@@ -52,11 +52,11 @@ TEST_F(SSDFixture, run_with_read_command)
 
 TEST_F(SSDFixture, run_with_read_command_but_invalid_addr)
 {
-	//1. ssd.exe r 110 È£Ãâ½Ã
+	//1. ssd.exe r 110 í˜¸ì¶œì‹œ
 	int argc = 3;
 	const char* argv[] = { "ssd.exe", "r", "110" };
 
-	//2. output¿¡ ERROR¸¦ Àû±æ ±â´ëÇÕ´Ï´Ù.
+	//2. outputì— ERRORë¥¼ ì ê¸¸ ê¸°ëŒ€í•©ë‹ˆë‹¤.
 	vector<string> expectedOutput = { "ERROR" };
 	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
 		.Times(1);

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -2,6 +2,7 @@
 #include "ssd.h"
 #include "file_handler_mock.h"
 using namespace testing;
+
 TEST(SSD, run_with_read_command)
 {
 	// arrange
@@ -20,6 +21,24 @@ TEST(SSD, run_with_read_command)
 
 	//3. output에 0x11111111을 적길 기대합니다.
 	vector<string> expectedOutput = { "0x11111111" };
+	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
+		.Times(1);
+
+	ssd.run(argc, argv);
+}
+
+TEST(SSD, run_with_read_command_but_invalid_addr)
+{
+	// arrange
+	FileHandlerMock mockedFileHandler;
+	SSD ssd = SSD(&mockedFileHandler);
+
+	//1. ssd.exe r 110 호출시
+	int argc = 3;
+	const char* argv[] = { "ssd.exe", "r", "110" };
+
+	//2. output에 ERROR를 적길 기대합니다.
+	vector<string> expectedOutput = { "ERROR" };
 	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
 		.Times(1);
 

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -3,36 +3,55 @@
 #include "file_handler_mock.h"
 using namespace testing;
 
-TEST(SSD, run_with_read_command)
-{
-	// arrange
+class SSDFixture : public Test {
+public:
 	FileHandlerMock mockedFileHandler;
-	SSD ssd = SSD(&mockedFileHandler);
+	SSD ssd{&mockedFileHandler};
 
+	// mocking nand 데이터. 
+	// n번째 addr의 값은 n의 16진수 표현. (ex  15\t0x0000000f )
+	vector<string> getMockedData() {
+		vector<string> ret;
+		for (int i = 0; i < 100; i++) {
+			std::ostringstream oss;
+			// 10진수와 탭
+			oss << i << '\t'
+				// "0x" 접두사
+				<< "0x"
+				// 16진수, 소문자, 폭 8, '0' 채움
+				<< std::hex << std::nouppercase << std::setw(8) << std::setfill('0')
+				<< i;
+			// 다시 10진수 모드로 복원(다음 루프에서 안전하게 사용하기 위해)
+			oss << std::dec;
+
+			ret.push_back(oss.str());
+		}
+		return ret;
+	}
+};
+
+TEST_F(SSDFixture, run_with_read_command)
+{
 	//1. ssd.exe r 0 호출시
 	int argc = 3;
-	const char* argv[] = {"ssd.exe", "r", "0" };
+	const char* argv[] = {"ssd.exe", "r", "1" };
 
 	//2. ssd_nand.txt에 아래와 같이 작성되어있다면
-	vector<string> writtenData = { "0\t0x11111111","1\t0x22222222" };
+	vector<string> writtenData = getMockedData();
 	EXPECT_CALL(mockedFileHandler, read("ssd_nand.txt"))
 		.Times(1)
 		.WillRepeatedly(Return(writtenData));
 
-	//3. output에 0x11111111을 적길 기대합니다.
-	vector<string> expectedOutput = { "0x11111111" };
+	//3. output에 0x00000001을 적길 기대합니다.
+	vector<string> expectedOutput = { "0x00000001" };
 	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
 		.Times(1);
 
 	ssd.run(argc, argv);
 }
 
-TEST(SSD, run_with_read_command_but_invalid_addr)
+TEST_F(SSDFixture, run_with_read_command_but_invalid_addr)
 {
-	// arrange
-	FileHandlerMock mockedFileHandler;
-	SSD ssd = SSD(&mockedFileHandler);
-
 	//1. ssd.exe r 110 호출시
 	int argc = 3;
 	const char* argv[] = { "ssd.exe", "r", "110" };


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1. SSD Run 으로 Read 할 수 있도록 구현했습니다.
2. FileHandler Mocking을 위해 SSD 는 main에서 FileHandler 를 생성자 주입받습니다.
3. SSD 내부에서 ArgumentParser 를 이용해 파싱후 명령어에 따라 Reader 나 Writer를 호출해 동작합니다.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
