### PR TITLE
parser에 명령어 미입력 예외 TC 추가

### DIFF
--- a/SSD/ArgumentParser_test.cpp
+++ b/SSD/ArgumentParser_test.cpp
@@ -97,3 +97,12 @@ TEST(ArgumentParserTest, WriteCommandExceptionNotEnoughArgumentTest2) {
 
 	EXPECT_THROW(parser.parse_args(3, argv), std::invalid_argument);
 }
+
+TEST(ArgumentParserTest, NoCommandExceptionTest) {
+	ArgumentParser parser;
+	const char* argv[] = {
+		"ssd.exe"
+	};
+
+	EXPECT_THROW(parser.parse_args(1, argv), std::invalid_argument);
+}


### PR DESCRIPTION
패치 내용
- parser에 명령어 미입력 예외 TC 추가
패치 세부 내용
1. SSD.exe에 명령어 미입력 TC 추가

이 부분은 중점적으로 봐주세요
- 명령어 parsing에서 빠진 예외가 있는지 확인 부탁드립니다.

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
