### PR TITLE
nand write impl 과 ssd 에서 write 호출하는 부분 구현

### DIFF
--- a/SSD/ArgumentParser.cpp
+++ b/SSD/ArgumentParser.cpp
@@ -25,8 +25,8 @@ bool ArgumentParser::write_cmd_handler(int argc, const char* argv[])
 	nAddr = atoi(argv[ARG_IDX_ADDR]);
 	if ((nAddr < 0) || (nAddr > 99)) throw std::invalid_argument("Out of range");
 
-	dwData = static_cast<unsigned int>(parseHexAddress(string(argv[ARG_IDX_DATA])));
-
+	parseHexAddress(string(argv[ARG_IDX_DATA]));
+	dwData = argv[ARG_IDX_DATA];
 	return true;
 }
 
@@ -60,7 +60,7 @@ int ArgumentParser::getAddr()
 	return nAddr;
 }
 
-unsigned int ArgumentParser::getData()
+string ArgumentParser::getData()
 {
 	return dwData;
 }

--- a/SSD/ArgumentParser.h
+++ b/SSD/ArgumentParser.h
@@ -18,7 +18,7 @@ public:
 
 	CMD_TYPE getCmdType();
 	int getAddr();
-	unsigned int getData();
+	string getData();
 
 private:
 	bool read_cmd_handler(int argc, const char* argv[]);
@@ -30,7 +30,7 @@ private:
 
 	CMD_TYPE eCmd = NONE_CMD;
 	int nAddr = -1;
-	unsigned int dwData = 0;
+	string dwData = "";
 
 	const int ARG_IDX_CMD = 1;
 	const int ARG_IDX_ADDR = 2;

--- a/SSD/ArgumentParser_test.cpp
+++ b/SSD/ArgumentParser_test.cpp
@@ -50,7 +50,7 @@ TEST(ArgumentParserTest, WriteCommandTest) {
 
 	EXPECT_EQ(ArgumentParser::WRITE_CMD, parser.getCmdType());
 	EXPECT_EQ(20, parser.getAddr());
-	EXPECT_EQ(0xAAAABBBB, parser.getData());
+	EXPECT_EQ("0xAAAABBBB", parser.getData());
 }
 
 TEST(ArgumentParserTest, WriteCommandExceptionTest) {

--- a/SSD/nand_flash_memory_impl.cpp
+++ b/SSD/nand_flash_memory_impl.cpp
@@ -1,3 +1,7 @@
+#include <sstream>
+#include <iomanip>
+#include <string>
+#include <iostream>
 #include "nand_flash_memory_impl.h"
 
 vector<string> NandFlashMemoryImpl::read() {
@@ -10,6 +14,13 @@ vector<string> NandFlashMemoryImpl::read() {
 	return ret;
 }
 
-string NandFlashMemoryImpl::write(const vector<string>& data) {
+string NandFlashMemoryImpl::write(const vector<string>& datas) {
+	vector<string> ret;
+	for (int i = 0; i < 100; i++) {
+		std::ostringstream oss;
+		oss << i << '\t' << datas.at(i);
+		ret.push_back(oss.str());
+	}
+	fileHandler->write(NAND_FILENAME, ret);
 	return "";
 }

--- a/SSD/nand_flash_memory_impl_test.cpp
+++ b/SSD/nand_flash_memory_impl_test.cpp
@@ -23,10 +23,18 @@ TEST(NandFlashMemoryImpl, writeTest) {
 	FileHandlerMock mockedFileHandler;
 	NandFlashMemoryImpl memory{ &mockedFileHandler };
 
-	vector<string> writingDatas = { "0\t0x00000000","1\t0x00000001" };
-	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt",writingDatas)).Times(1);
-	vector<string> writingData = { "0x00000000", "0x00000001" };
-	string actual = memory.write(writingData);
+	vector<string> expectingWriteDatas;
+	for (int i = 0; i < 100; i++) {
+		std::ostringstream oss;
+		oss << i << '\t' << "0x00001111";
+		expectingWriteDatas.push_back(oss.str());
+	}
+	vector<string> writingDatas;
+	for (int i = 0; i < 100; i++) {
+		writingDatas.push_back("0x00001111");
+	}
+	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt", expectingWriteDatas)).Times(1);
+	string actual = memory.write(writingDatas);
 
 	EXPECT_EQ("", actual);
 }

--- a/SSD/nand_flash_memory_impl_test.cpp
+++ b/SSD/nand_flash_memory_impl_test.cpp
@@ -18,3 +18,15 @@ TEST(NandFlashMemoryImpl, readTest) {
 
 	EXPECT_EQ(expected, actual);
 }
+
+TEST(NandFlashMemoryImpl, writeTest) {
+	FileHandlerMock mockedFileHandler;
+	NandFlashMemoryImpl memory{ &mockedFileHandler };
+
+	vector<string> writingDatas = { "0\t0x00000000","1\t0x00000001" };
+	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt",writingDatas)).Times(1);
+	vector<string> writingData = { "0x00000000", "0x00000001" };
+	string actual = memory.write(writingData);
+
+	EXPECT_EQ("", actual);
+}

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -30,6 +30,9 @@ void SSD::run(int argc, const char* argv[])
 			break;
 		}
 		case ArgumentParser::WRITE_CMD: {
+			int addr = argumentParser->getAddr();
+			string data = argumentParser->getData();
+			writer->write(addr, data);
 			break;
 		}
 		default: {

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -63,3 +63,29 @@ TEST_F(SSDFixture, run_with_read_command_but_invalid_addr)
 
 	ssd.run(argc, argv);
 }
+
+TEST_F(SSDFixture, run_with_write_command)
+{
+	//1. ssd.exe r 0 호출시
+	int argc = 3;
+	char newData[] = "0x00001111";
+	const char* argv[] = { "ssd.exe", "w", "1", newData };
+
+	//2. ssd_nand.txt에 아래와 같이 작성되어있다면
+	vector<string> writtenData = getMockedData();
+	EXPECT_CALL(mockedFileHandler, read("ssd_nand.txt"))
+		.Times(1)
+		.WillRepeatedly(Return(writtenData));
+
+	vector<string> newDatas = getMockedData();
+	newDatas[1] = newData;
+	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt", newDatas))
+		.Times(1);
+
+	//3. output에 0x00000001을 적길 기대합니다.
+	vector<string> expectedOutput = { "" };
+	EXPECT_CALL(mockedFileHandler, write("ssd_output.txt", expectedOutput))
+		.Times(1);
+
+	ssd.run(argc, argv);
+}

--- a/SSD/ssd_test.cpp
+++ b/SSD/ssd_test.cpp
@@ -67,7 +67,7 @@ TEST_F(SSDFixture, run_with_read_command_but_invalid_addr)
 TEST_F(SSDFixture, run_with_write_command)
 {
 	//1. ssd.exe r 0 호출시
-	int argc = 3;
+	int argc = 4;
 	char newData[] = "0x00001111";
 	const char* argv[] = { "ssd.exe", "w", "1", newData };
 
@@ -78,7 +78,7 @@ TEST_F(SSDFixture, run_with_write_command)
 		.WillRepeatedly(Return(writtenData));
 
 	vector<string> newDatas = getMockedData();
-	newDatas[1] = newData;
+	newDatas[1] = "1\t0x00001111";
 	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt", newDatas))
 		.Times(1);
 


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1. NandFlashMemoryImpl 의 write 기능 구현
2. SSD 에서 Write 명령어 구현
3. ArgParser 에서 getData 의 리턴타입을 string으로 변경

이 부분은 중점적으로 봐주세요
- 

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
