### PR TITLE
Test shell/2 script enable

### DIFF
--- a/TestShell/command.cpp
+++ b/TestShell/command.cpp
@@ -108,6 +108,34 @@ void FullWriteAndReadCompare::run(const CommandRunner& cmdRunner) const
 
 void PartialLBAWrite::run(const CommandRunner& cmdRunner) const
 {
+	for (int testRepeat = 0; testRepeat < REPEAT_COUNT; testRepeat++) {
+		vector<std::string> result;
+
+		for (std::string Lba : TestLbaList) {
+			cmdRunner.write(Lba, WRITE_DATA);
+		}
+
+		for (std::string Lba : TestLbaList) {
+
+			result.push_back(cmdRunner.read(Lba));
+		}
+
+		if (checkResult(result) == false) {
+			std::cout << "FAIL\n";
+		}
+	}
+	std::cout << "PASS\n";
+}
+
+bool PartialLBAWrite::checkResult(const vector<std::string>& result) const
+{
+	string firstItem = result[0];
+
+	for (const std::string& resultitem : result)
+	{
+		if (resultitem != firstItem) { return false; }
+	}
+	return true;
 }
 
 void WriteReadAging::run(const CommandRunner& cmdRunner) const
@@ -134,6 +162,8 @@ Command* FactoryCommand::makeCommand(const std::string& cmd)
 	else if (shellCmd == CMD_FULLWRITE) return new FullWriteCommand(commands);
 	else if (shellCmd == CMD_FULLREAD) return new FullReadCommand(commands);
 	else if (shellCmd == CMD_1_ || shellCmd == CMD_1_FULLWRITEANDREADCOMPARE) return new FullWriteAndReadCompare(commands);
+
+	else if ((shellCmd == CMD_2_PartialLBAWrite) || (shellCmd == CMD_2_)) return new PartialLBAWrite(commands);
 
 	else return nullptr;
 }

--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -12,6 +12,8 @@ namespace {
 	const std::string CMD_FULLREAD = "fullread";
 	const std::string CMD_1_FULLWRITEANDREADCOMPARE = "1_FullWriteAndReadCompare";
 	const std::string CMD_1_ = "1_";
+	const std::string CMD_2_PartialLBAWrite = "2_PartialLBAWrite";
+	const std::string CMD_2_ = "2_";
 }
 
 class Command {
@@ -114,6 +116,12 @@ public:
 		help = "PartialLBAWrite";
 	};
 	void run(const CommandRunner& cmdRunner) const override;
+private:
+	static const int REPEAT_COUNT = 30;
+	const std::string WRITE_DATA{ "0x12341234" };
+	std::vector<std::string> TestLbaList = { "4","0","3","1","2" };
+
+	bool checkResult(const std::vector<std::string>& result) const;
 };
 
 class WriteReadAging : public Command {

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -123,3 +123,21 @@ TEST_F(TestShellFixtureWithMock, CommandRunFullWriteAndReadCompare) {
 
 	command->run(runner);
 }
+
+TEST_F(TestShellFixtureWithMock, PartialLBAWrite) {
+	static const int OPERATION_CALL_COUNT = 150;
+	vector<string> user_input_command = { "2_", "2_PartialLBAWrite"};
+	for (string user_input : user_input_command) {
+		Command* command = fc.makeCommand(user_input);
+
+		EXPECT_CALL(mockStorage, read(_))
+			.Times(OPERATION_CALL_COUNT)
+			.WillRepeatedly(Return("0xA5A5A5A5"));
+
+		EXPECT_CALL(mockStorage, write(_, _))
+			.Times(OPERATION_CALL_COUNT)
+			.WillRepeatedly(Return(""));
+
+		command->run(runner);
+	}
+}


### PR DESCRIPTION
패치 내용
-  2_PartialLBAWrite 기능을 구현하였습니다.
패치 세부 내용
1.2_PartialLBAWrite TC 구현하였습니다.
   일단은 Read/Write가 지정된 횟수만큼 다 수행하는 지를 확인하는 TC를 추가하였습니다.
2. 2_PartialLBAWrite 기능 enable 하였습니다.
3. 

이 부분은 중점적으로 봐주세요
-
```
30회 반복
4번 LBA에 값을 적는다.
0번 LBA에 같은 값을 적는다.
3번 LBA에 같은 값을 적는다.
1번 LBA에 같은 값을 적는다.
2번 LBA에 같은 값을 적는다.
LBA 0 ~ 4번 모두 같은지 확인
```
위 시나리오대로 수행이 되는 지 확인해주시면 될 것 같습니다.
해당 commit은  RED/GREEN에 해당되는 내용이어서 Refac은 추후에 하겠습니다.
Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
