### PR TITLE
SSD argument parser에서 문자 비교 버그 수정

### DIFF
--- a/SSD/ArgumentParser.cpp
+++ b/SSD/ArgumentParser.cpp
@@ -39,6 +39,8 @@ bool ArgumentParser::etc_cmd_handler(int argc, const char* argv[])
 
 bool ArgumentParser::parse_args(int argc, const char* argv[])
 {
+	if (argc < 2) throw std::invalid_argument("no command");
+
 	if ((string(argv[ARG_IDX_CMD]) == string("R")) || (string(argv[ARG_IDX_CMD]) == string("r"))) {
 		return read_cmd_handler(argc, argv);
 	}

--- a/SSD/ArgumentParser.cpp
+++ b/SSD/ArgumentParser.cpp
@@ -39,10 +39,10 @@ bool ArgumentParser::etc_cmd_handler(int argc, const char* argv[])
 
 bool ArgumentParser::parse_args(int argc, const char* argv[])
 {
-	if ((argv[ARG_IDX_CMD] == "R") || (argv[ARG_IDX_CMD] == "r")) {
+	if ((string(argv[ARG_IDX_CMD]) == string("R")) || (string(argv[ARG_IDX_CMD]) == string("r"))) {
 		return read_cmd_handler(argc, argv);
 	}
-	else if ((argv[ARG_IDX_CMD] == "W") || (argv[ARG_IDX_CMD] == "w")) {
+	else if ((string(argv[ARG_IDX_CMD]) == string("W")) || (string(argv[ARG_IDX_CMD]) == string("w"))) {
 		return write_cmd_handler(argc, argv);
 	}
 	else {

--- a/SSD/ArgumentParser.cpp
+++ b/SSD/ArgumentParser.cpp
@@ -39,7 +39,7 @@ bool ArgumentParser::etc_cmd_handler(int argc, const char* argv[])
 
 bool ArgumentParser::parse_args(int argc, const char* argv[])
 {
-	if (argc < 2) throw std::invalid_argument("no command");
+	if (argc < MIN_ARG_CNT) throw std::invalid_argument("no command");
 
 	if ((string(argv[ARG_IDX_CMD]) == string("R")) || (string(argv[ARG_IDX_CMD]) == string("r"))) {
 		return read_cmd_handler(argc, argv);

--- a/SSD/global_config.h
+++ b/SSD/global_config.h
@@ -8,6 +8,7 @@
 #define ARG_IDX_CMD		1
 #define ARG_IDX_ADDR	2
 #define ARG_IDX_DATA	3
+#define MIN_ARG_CNT     2
 
 // File
 #define NAND_FILENAME "ssd_nand.txt"


### PR DESCRIPTION
패치 내용
- SSD argument parser에서 문자 비교 버그 수정
- char *argv[] 와 character를 비교하는 버그가 있었습니다. string으로 변환하여 비교 or strcmp() 를 사용해야 하는데, 
   추후 cmd의 char가 1개 이상이 되는 경우를 대비하여 string type으로 변환하여 비교하도록 수정했습니다.

패치 세부 내용
1. character type을 string으로 변환하여 비교
2. 추후 명령어가 char 1개가 아닌 경우에 대비하여 string type 사용
3. 상수값은 GlobalConfig.h에 정의한 값으로 사용

이 부분은 중점적으로 봐주세요
- 문자열 비교에서 예외 사항이 있을 지 확인 부탁드립니다.

Check lists
- [X] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [X] Unit Test 100% 통과 확인 (master branch 기준)
- [X] 이상한 파일이 들어가지 않았는지 확인
