### PR TITLE
ssd_nand.txt 초기 파일 생성

### DIFF
--- a/SSD/FileHandler.cpp
+++ b/SSD/FileHandler.cpp
@@ -1,9 +1,50 @@
 #include <fstream>
+#include <stdexcept>
+#include <iomanip>
 #include "FileHandler.h"
 
 using std::string;
 using std::ofstream;
 using std::ifstream;
+
+FileHandler::FileHandler()
+{
+	
+}
+
+void FileHandler::init()
+{
+	if (checkExistNandFile(NAND_FILENAME) == false)
+	{
+		createInitNandFile(NAND_FILENAME);
+	}
+}
+
+bool FileHandler::checkExistNandFile(const string& file_name)
+{
+	ifstream readfile;
+	readfile.open(file_name);
+	return !(readfile.fail());
+}
+
+void FileHandler::createInitNandFile(const string& file_name)
+{
+	ofstream outfile(file_name);
+
+	if (!outfile.is_open()) {
+		throw std::exception("Fail to create ssd_nand.txt");
+	}
+
+	for (int i = MIN_LBA; i <= MAX_LBA; ++i) {
+		outfile << std::setw(2) << std::setfill('0') << std::dec << i << '\t'
+			<< "0x"
+			<< std::setw(8) << std::setfill('0') << std::hex << std::uppercase << 0
+			<< '\n';
+	}
+
+	outfile.close();
+	return;
+}
 
 void FileHandler::write(const string& file_name, const vector<string>& output_string) {
 	ofstream writefile;

--- a/SSD/FileHandler.h
+++ b/SSD/FileHandler.h
@@ -2,6 +2,7 @@
 #include <string>
 #include <fstream>
 #include <vector>
+#include "global_config.h"
 
 using std::ofstream;
 using std::string;
@@ -9,11 +10,13 @@ using std::vector;
 
 class FileHandler {
 public:
-	FileHandler() {}
+	FileHandler();
 
+	void init();
+	virtual bool checkExistNandFile(const string& file_name);
+	virtual void createInitNandFile(const string& file_name);
 	virtual void write(const string& file_name, const vector<string>& output_string);
 	virtual vector<string> read(const string& file_name);
 
 private:
-
 };

--- a/SSD/OutputHandler.h
+++ b/SSD/OutputHandler.h
@@ -12,6 +12,7 @@ public:
 
 	void output(const string& output_string);
 	string read(void);
+	FileHandler* getFileHandler() { return fileHandler; }
 
 private:
 	FileHandler* fileHandler;

--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -131,7 +131,12 @@
     <ClCompile Include="ArgumentParser_test.cpp" />
     <ClCompile Include="file_handler_mock.h" />
     <ClCompile Include="nand_flash_memory_impl.cpp" />
-    <ClCompile Include="nand_flash_memory_impl_test.cpp" />
+    <ClCompile Include="nand_flash_memory_impl_test.cpp">
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'"> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'"> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|x64'"> %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
     <ClCompile Include="nand_writer.cpp" />
     <ClCompile Include="nand_writer_test.cpp" />
     <ClCompile Include="ssd.cpp" />

--- a/SSD/file_handler_mock.h
+++ b/SSD/file_handler_mock.h
@@ -4,6 +4,8 @@
 
 class FileHandlerMock : public FileHandler {
 public:
+	MOCK_METHOD(bool, checkExistNandFile, (const string&), (override));
+	MOCK_METHOD(void, createInitNandFile, (const string&), (override));
 	MOCK_METHOD(void, write, (const string&, const vector<string>&), (override));
 	MOCK_METHOD(vector<string>, read, (const string&), (override));
 };

--- a/SSD/nand_flash_memory_impl_test.cpp
+++ b/SSD/nand_flash_memory_impl_test.cpp
@@ -7,10 +7,33 @@
 using namespace testing;
 using std::vector;
 
-TEST(NandFlashMemoryImpl, readTest) {
+class NandFlashMemoryImplFixture : public Test {
+public:
+	vector<string> GetFullDataWithLBA()
+	{
+		vector<string> expectingWriteDatas;
+		for (int i = MIN_LBA; i <= MAX_LBA; i++) {
+			std::ostringstream oss;
+			oss << i << '\t' << "0x00001111";
+			expectingWriteDatas.push_back(oss.str());
+		}
+		return expectingWriteDatas;
+	}
+
+	vector<string> GetFullDataWihtoutLBA()
+	{
+		vector<string> writingDatas;
+		for (int i = MIN_LBA; i <= MAX_LBA; i++) {
+			writingDatas.push_back("0x00001111");
+		}
+		return writingDatas;
+	}
+
 	FileHandlerMock mockedFileHandler;
 	NandFlashMemoryImpl memory{ &mockedFileHandler };
+};
 
+TEST_F(NandFlashMemoryImplFixture, readTest) {
 	vector<string> writtenDatas = { "0\t0x00000000","1\t0x00000001" };
 	EXPECT_CALL(mockedFileHandler, read("ssd_nand.txt")).WillRepeatedly(Return(writtenDatas));
 	vector<string> expected = { "0x00000000", "0x00000001" };
@@ -19,20 +42,10 @@ TEST(NandFlashMemoryImpl, readTest) {
 	EXPECT_EQ(expected, actual);
 }
 
-TEST(NandFlashMemoryImpl, writeTest) {
-	FileHandlerMock mockedFileHandler;
-	NandFlashMemoryImpl memory{ &mockedFileHandler };
-
-	vector<string> expectingWriteDatas;
-	for (int i = 0; i < 100; i++) {
-		std::ostringstream oss;
-		oss << i << '\t' << "0x00001111";
-		expectingWriteDatas.push_back(oss.str());
-	}
-	vector<string> writingDatas;
-	for (int i = 0; i < 100; i++) {
-		writingDatas.push_back("0x00001111");
-	}
+TEST_F(NandFlashMemoryImplFixture, writeTest) {
+	vector<string> expectingWriteDatas = GetFullDataWithLBA();
+	vector<string> writingDatas = GetFullDataWihtoutLBA();
+	
 	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt", expectingWriteDatas)).Times(1);
 	string actual = memory.write(writingDatas);
 

--- a/SSD/nand_flash_memory_impl_test.cpp
+++ b/SSD/nand_flash_memory_impl_test.cpp
@@ -9,22 +9,22 @@ using std::vector;
 
 class NandFlashMemoryImplFixture : public Test {
 public:
-	vector<string> GetFullDataWithLBA()
+	vector<string> GetFullSameDataWithLBA(string data)
 	{
 		vector<string> expectingWriteDatas;
 		for (int i = MIN_LBA; i <= MAX_LBA; i++) {
 			std::ostringstream oss;
-			oss << i << '\t' << "0x00001111";
+			oss << i << '\t' << data;
 			expectingWriteDatas.push_back(oss.str());
 		}
 		return expectingWriteDatas;
 	}
 
-	vector<string> GetFullDataWihtoutLBA()
+	vector<string> GetFullSameDataWihtoutLBA(string data)
 	{
 		vector<string> writingDatas;
 		for (int i = MIN_LBA; i <= MAX_LBA; i++) {
-			writingDatas.push_back("0x00001111");
+			writingDatas.push_back(data);
 		}
 		return writingDatas;
 	}
@@ -43,11 +43,31 @@ TEST_F(NandFlashMemoryImplFixture, readTest) {
 }
 
 TEST_F(NandFlashMemoryImplFixture, writeTest) {
-	vector<string> expectingWriteDatas = GetFullDataWithLBA();
-	vector<string> writingDatas = GetFullDataWihtoutLBA();
+	vector<string> expectingWriteDatas = GetFullSameDataWithLBA("0x00001111");
+	vector<string> writingDatas = GetFullSameDataWihtoutLBA("0x00001111");
 	
-	EXPECT_CALL(mockedFileHandler, write("ssd_nand.txt", expectingWriteDatas)).Times(1);
+	EXPECT_CALL(mockedFileHandler, write(NAND_FILENAME, expectingWriteDatas)).Times(1);
 	string actual = memory.write(writingDatas);
 
 	EXPECT_EQ("", actual);
+}
+
+TEST_F(NandFlashMemoryImplFixture, NandFile_Exist) {
+	EXPECT_CALL(mockedFileHandler, checkExistNandFile)
+		.Times(1)
+		.WillOnce(Return(true));
+	EXPECT_CALL(mockedFileHandler, createInitNandFile)
+		.Times(0);
+
+	mockedFileHandler.init();
+}
+
+TEST_F(NandFlashMemoryImplFixture, NandFile_NoExist) {
+	EXPECT_CALL(mockedFileHandler, checkExistNandFile)
+		.Times(1)
+		.WillOnce(Return(false));
+	EXPECT_CALL(mockedFileHandler, createInitNandFile)
+		.Times(1);
+
+	mockedFileHandler.init();
 }

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -22,6 +22,8 @@ void SSD::run(int argc, const char* argv[])
 {
 	string data = "";
 	try {
+		outputHandler->getFileHandler()->init();
+
 		argumentParser->parse_args(argc, argv);
 		switch (argumentParser->getCmdType()) {
 		case ArgumentParser::READ_CMD: {


### PR DESCRIPTION
패치 내용
- ssd_nand.txt 초기 파일 생성

패치 세부 내용
1. NandFlashMemoryImplFixutre 도입
2. ssd_nand.txt 초기 파일 생성 TC 추가
3. ssd_nand.txt 초기 파일 생성부 구현

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
