### PR TITLE
Logger 기능 추가 PR

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -135,11 +135,13 @@
     <ClCompile Include="full_write_and_read_compare_command.cpp" />
     <ClCompile Include="full_write_command.cpp" />
     <ClCompile Include="help_command.cpp" />
+    <ClCompile Include="logger.cpp" />
     <ClCompile Include="main.cpp" />
     <ClCompile Include="partial_LBA_write_command.cpp" />
     <ClCompile Include="read_command.cpp" />
     <ClCompile Include="shell.cpp" />
     <ClCompile Include="test_command.cpp" />
+    <ClCompile Include="test_logger.cpp" />
     <ClCompile Include="test_testshell_command_parser.cpp" />
     <ClCompile Include="test_with_mock.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'"> %(AdditionalOptions)</AdditionalOptions>
@@ -164,6 +166,7 @@
     <ClInclude Include="full_write_and_read_compare_command.h" />
     <ClInclude Include="full_write_command.h" />
     <ClInclude Include="help_command.h" />
+    <ClInclude Include="logger.h" />
     <ClInclude Include="partial_LBA_write_command.h" />
     <ClInclude Include="read_command.h" />
     <ClInclude Include="shell.h" />

--- a/TestShell/TestShell.vcxproj.filters
+++ b/TestShell/TestShell.vcxproj.filters
@@ -64,6 +64,12 @@
     <ClCompile Include="command_factory.cpp">
       <Filter>소스 파일\cmds</Filter>
     </ClCompile>
+    <ClCompile Include="test_logger.cpp">
+      <Filter>테스트 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="logger.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="command_parser.h">
@@ -110,6 +116,9 @@
     </ClInclude>
     <ClInclude Include="command_list.h">
       <Filter>헤더 파일\cmds</Filter>
+    </ClInclude>
+    <ClInclude Include="logger.h">
+      <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/TestShell/logger.cpp
+++ b/TestShell/logger.cpp
@@ -1,0 +1,105 @@
+#include <fstream>
+#include <iomanip>
+#include <chrono>
+#include <ctime>
+#include <string>
+#include <sstream>
+#include <iostream>
+#include <windows.h>
+#include <vector>
+#include "logger.h"
+
+void Logger::print(const std::string& functionName, const std::string& message) {
+
+	checkRenameFIles();
+
+	std::string timestamp = getCurrentTimestamp();
+	logFile << "[" << timestamp << "] "
+		<< std::left << std::setw(16) << functionName
+		<< ": " << message << std::endl;
+}
+std::size_t Logger::getLogFileSize() {
+	std::ifstream file(LOGFILE_NAME, std::ios::binary);
+	if (!file.is_open()) return 0;
+
+	file.seekg(0, std::ios::end);
+	return static_cast<std::size_t>(file.tellg());
+}
+
+Logger::Logger() {
+	openLogFile();
+}
+
+Logger::~Logger() {
+	if (logFile.is_open()) {
+		logFile.close();
+	}
+}
+
+void Logger::openLogFile() {
+	logFile.open(logFileName, std::ios::app);
+	if (!logFile.is_open()) {
+		throw std::runtime_error("Cannot open " + LOGFILE_NAME);
+	}
+}
+
+std::string Logger::getCurrentTimestamp() {
+	auto now = std::chrono::system_clock::now();
+	std::time_t nowT = std::chrono::system_clock::to_time_t(now);
+	std::tm timeInfo;
+	localtime_s(&timeInfo, &nowT);
+
+	char buffer[20];
+	std::strftime(buffer, sizeof(buffer), "%y.%m.%d %H:%M", &timeInfo);
+	return std::string(buffer);
+}
+
+std::string Logger::getFileTimeForName() {
+	auto now = std::chrono::system_clock::now();
+	std::time_t nowTimeT = std::chrono::system_clock::to_time_t(now);
+	std::tm timeInfo;
+	localtime_s(&timeInfo, &nowTimeT);
+
+	char buffer[30];
+	std::strftime(buffer, sizeof(buffer), "%y%m%d_%H_%M_%S", &timeInfo);
+	return std::string(buffer);
+}
+
+void Logger::renamePreviousLogFiles() {
+	WIN32_FIND_DATAA findFileData;
+	HANDLE hFind = FindFirstFileA(LOGFILE_SEARCH_PATTERN.c_str(), &findFileData);
+	int tryCnt = 0;
+
+	if (hFind == INVALID_HANDLE_VALUE)
+		return;
+
+	do {
+		std::string oldName = findFileData.cFileName;
+
+		std::string baseName = oldName.substr(0, oldName.find_last_of('.'));
+		std::string newName = baseName + LOGFILE_ZIP_EXTENSION;
+
+		while (!MoveFileA(oldName.c_str(), newName.c_str())) {
+			newName = baseName + "_" + LOGFILE_ZIP_EXTENSION;
+			baseName += "(2)";
+
+			if (tryCnt++ > 3)
+				break;
+		}
+
+	} while (FindNextFileA(hFind, &findFileData) != 0);
+	FindClose(hFind);
+}
+
+void Logger::checkRenameFIles() {
+	if (getLogFileSize() < maxFileSize) return;
+
+	logFile.close();
+
+	renamePreviousLogFiles();
+
+	std::string newName = LOGFILE_PREFIX + getFileTimeForName() + LOGFILE_EXTENSION;
+	MoveFileA(logFileName.c_str(), newName.c_str());
+
+	openLogFile();
+}

--- a/TestShell/logger.h
+++ b/TestShell/logger.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#define logger Logger::getInstance()
+
+namespace {
+	const std::string LOGFILE_PREFIX = "until_";
+	const std::string LOGFILE_EXTENSION = ".log";
+	const std::string LOGFILE_ZIP_EXTENSION = ".zip";
+	const std::string LOGFILE_NAME = "latest" + LOGFILE_EXTENSION;
+	const int LOGFILE_MAXSIZE = 10 * 1024;
+	const std::string LOGFILE_SEARCH_PATTERN = LOGFILE_PREFIX + "*" + LOGFILE_EXTENSION;
+}
+
+class Logger {
+public:
+	static Logger& getInstance() {
+		static Logger instance;
+		return instance;
+	}
+
+	void print(const std::string& functionName, const std::string& message);
+	std::size_t getLogFileSize();
+
+private:
+	Logger();
+	~Logger();
+
+	Logger(const Logger&) = delete;
+	Logger& operator=(const Logger&) = delete;
+
+	std::ofstream logFile;
+	const std::string logFileName = LOGFILE_NAME;
+	const std::size_t maxFileSize = LOGFILE_MAXSIZE;
+
+	void openLogFile();
+	std::string getCurrentTimestamp();
+	std::string getFileTimeForName();
+	void renamePreviousLogFiles();
+	void checkRenameFIles();
+};

--- a/TestShell/test_logger.cpp
+++ b/TestShell/test_logger.cpp
@@ -107,7 +107,7 @@ TEST_F(LoggerTest, AppendLogsToExistingFile) {
 	EXPECT_NE(after.find(__DATE__), std::string::npos);
 }
 
-//10KB 로그파일을 계속 생성하기 때문에, 필요시 Enable.
+//Default : DISABLE
 TEST_F(LoggerTest, DISABLED_AppendLogsOver10KB) {
 
 	int numOfUntilLogfiles = getNumOfFiles("until_", ".log");
@@ -125,7 +125,7 @@ TEST_F(LoggerTest, DISABLED_AppendLogsOver10KB) {
 	EXPECT_EQ(expect_zip, getNumOfFiles("until_", ".zip"));
 }
 
-//10KB 로그파일을 계속 생성하기 때문에, 필요시 Enable.
+//Default : DISABLE
 TEST_F(LoggerTest, DISABLED_AppendLogsOver30KB) {
 
 	int numOfUntilLogfiles = getNumOfFiles("until_", ".log");

--- a/TestShell/test_logger.cpp
+++ b/TestShell/test_logger.cpp
@@ -1,0 +1,146 @@
+#include <fstream>
+#include <string>
+#include <sstream>
+#include <windows.h>
+
+#include "gmock/gmock.h"
+#include "logger.h"
+
+namespace {
+	const std::string TEST_LOG_FILE = "latest.log";
+}
+
+class LoggerTest : public ::testing::Test {
+protected:
+	std::string readLogFile() {
+		std::ifstream file(TEST_LOG_FILE);
+		std::stringstream buffer;
+		buffer << file.rdbuf();
+		return buffer.str();
+	}
+
+	int getNumOfFiles(const std::string& prefix, const std::string& extension) {
+		WIN32_FIND_DATAA findData;
+		std::string searchPattern = prefix + "*" + extension;
+
+		int count = 0;
+		HANDLE hFind = FindFirstFileA(searchPattern.c_str(), &findData);
+		if (hFind == INVALID_HANDLE_VALUE) {
+			return 0;
+		}
+
+		do {
+			if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+				++count;
+			}
+		} while (FindNextFileA(hFind, &findData));
+
+		FindClose(hFind);
+		return count;
+	}
+
+	std::vector<std::string> getFilename(const std::string& prefix, const std::string& extension) {
+		std::vector<std::string> files;
+		std::string searchPattern = prefix + "*" + extension;
+
+		WIN32_FIND_DATAA findData;
+		HANDLE hFind = FindFirstFileA(searchPattern.c_str(), &findData);
+
+		if (hFind == INVALID_HANDLE_VALUE) {
+			return files;
+		}
+
+		do {
+			if (!(findData.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
+				files.push_back(findData.cFileName);
+			}
+		} while (FindNextFileA(hFind, &findData));
+
+		FindClose(hFind);
+		return files;
+	}
+
+	void logUntilMaxsize() {
+		int curSize = logger.getLogFileSize();
+		int prevSize = 0;
+
+		while (curSize > prevSize) {
+			logger.print(__func__, __TIMESTAMP__);
+
+			prevSize = curSize;
+			curSize = logger.getLogFileSize();
+		}
+	}
+};
+
+TEST_F(LoggerTest, AppendLogToExistingFile) {
+
+	std::string before = readLogFile();
+
+	logger.print(__func__, __DATE__);
+
+	std::string after = readLogFile();
+
+	EXPECT_GT(after.size(), before.size());
+
+	EXPECT_NE(after.find(__func__), std::string::npos);
+	EXPECT_NE(after.find(__DATE__), std::string::npos);
+}
+
+TEST_F(LoggerTest, AppendLogsToExistingFile) {
+
+	std::string before = readLogFile();
+
+	logger.print(__func__, __DATE__);
+	logger.print(__func__, __DATE__);
+	logger.print(__func__, __DATE__);
+
+	std::string after = readLogFile();
+
+	EXPECT_GT(after.size(), before.size());
+
+	EXPECT_NE(after.find(__func__), std::string::npos);
+	EXPECT_NE(after.find(__DATE__), std::string::npos);
+	EXPECT_NE(after.find(__func__), std::string::npos);
+	EXPECT_NE(after.find(__DATE__), std::string::npos);
+	EXPECT_NE(after.find(__func__), std::string::npos);
+	EXPECT_NE(after.find(__DATE__), std::string::npos);
+}
+
+//10KB 로그파일을 계속 생성하기 때문에, 필요시 Enable.
+TEST_F(LoggerTest, DISABLED_AppendLogsOver10KB) {
+
+	int numOfUntilLogfiles = getNumOfFiles("until_", ".log");
+	int numOfZipLogfiles = getNumOfFiles("until_", ".zip");
+	std::vector<std::string> files = getFilename("until_", ".log");
+
+	int expect_until, expect_zip;
+
+	expect_until = 1;
+	expect_zip = (numOfUntilLogfiles > 0) ? numOfZipLogfiles + 1 : 0;
+
+	logUntilMaxsize();
+
+	EXPECT_EQ(expect_until, getNumOfFiles("until_", ".log"));
+	EXPECT_EQ(expect_zip, getNumOfFiles("until_", ".zip"));
+}
+
+//10KB 로그파일을 계속 생성하기 때문에, 필요시 Enable.
+TEST_F(LoggerTest, DISABLED_AppendLogsOver30KB) {
+
+	int numOfUntilLogfiles = getNumOfFiles("until_", ".log");
+	int numOfZipLogfiles = getNumOfFiles("until_", ".zip");
+	std::vector<std::string> files = getFilename("until_", ".log");
+
+	int expect_until, expect_zip;
+
+	expect_until = 1;
+	expect_zip = (numOfUntilLogfiles > 0) ? numOfZipLogfiles + 3 : numOfZipLogfiles + 2;
+
+	logUntilMaxsize();
+	logUntilMaxsize();
+	logUntilMaxsize();
+
+	EXPECT_EQ(expect_until, getNumOfFiles("until_", ".log"));
+	EXPECT_EQ(expect_zip, getNumOfFiles("until_", ".zip"));
+}


### PR DESCRIPTION
패치 내용
- Logger 기능 추가
- Logger testcase 추가

패치 세부 내용
Logger
1. Logger는 프로그램 당 1개로 제한 (singleton으로 사용)
2. Multi threading 고려하지 않음 (lock 없음)
3. 요구사항대로, latest.log와 until______.log / until_____.zip을 생성함 (maxsize = 10K)
4. 사용법 아래 참고

Logger TC
1. Logger TC는 test용 log파일을 만들지 않습니다.
6. Log  backup파일을 계속 생산하는 TC는 Disable이 default입니다.

이 부분은 중점적으로 봐주세요
- Logger TC는 기본 logging test만 작동합니다. (10KB~30KB log는 Default disable)
- Logger 사용 방법은 아래와 같습니다.
``` 
#include "logger.h"
logger.print("function name", "message");
```

Check lists
- [X] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [X] Unit Test 100% 통과 확인 (master branch 기준)
- [X] 이상한 파일이 들어가지 않았는지 확인
