### PR TITLE
[Refactoring] ArgumentParser에 정의되어있던 CMD_TYPE을 global_config.h로 이동

### DIFF
--- a/SSD/ArgumentParser.cpp
+++ b/SSD/ArgumentParser.cpp
@@ -8,7 +8,7 @@ using std::string;
 
 bool ArgumentParser::read_cmd_handler(int argc, const char* argv[])
 {
-	eCmd = READ_CMD;
+	eCmd = CMD_READ;
 	checkArgNum(argc);
 
 	nAddr = atoi(argv[ARG_IDX_ADDR]);
@@ -19,7 +19,7 @@ bool ArgumentParser::read_cmd_handler(int argc, const char* argv[])
 
 bool ArgumentParser::write_cmd_handler(int argc, const char* argv[])
 {
-	eCmd = WRITE_CMD;
+	eCmd = CMD_WRITE;
 	checkArgNum(argc);
 
 	nAddr = atoi(argv[ARG_IDX_ADDR]);
@@ -33,7 +33,7 @@ bool ArgumentParser::write_cmd_handler(int argc, const char* argv[])
 
 bool ArgumentParser::erase_cmd_handler(int argc, const char* argv[])
 {
-	eCmd = ERASE_CMD;
+	eCmd = CMD_ERASE;
 	checkArgNum(argc);
 
 	nAddr = atoi(argv[ARG_IDX_ADDR]);
@@ -63,7 +63,7 @@ bool ArgumentParser::parse_args(int argc, const char* argv[])
 	return etc_cmd_handler(argc, argv);
 }
 
-ArgumentParser::CMD_TYPE ArgumentParser::getCmdType()
+CMD_TYPE ArgumentParser::getCmdType()
 {
 	return eCmd;
 }
@@ -85,15 +85,15 @@ string ArgumentParser::getData()
 
 void ArgumentParser::checkArgNum(int argc)
 {
-	if (eCmd == READ_CMD)
+	if (eCmd == CMD_READ)
 	{
 		if (argc != READ_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
 	}
-	else if (eCmd == WRITE_CMD)
+	else if (eCmd == CMD_WRITE)
 	{
 		if (argc != WRITE_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
 	}
-	else if (eCmd == ERASE_CMD)
+	else if (eCmd == CMD_ERASE)
 	{
 		if (argc != ERASE_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
 	}

--- a/SSD/ArgumentParser.h
+++ b/SSD/ArgumentParser.h
@@ -6,16 +6,10 @@
 #include <cstdlib>
 
 using std::string;
+typedef int CMD_TYPE;
 
 class ArgumentParser {
 public:
-	enum CMD_TYPE {
-		NONE_CMD = 0,
-		READ_CMD = 1,
-		WRITE_CMD = 2,
-		ERASE_CMD = 3,
-	};
-
 	bool parse_args(int argc, const char* argv[]);
 
 	CMD_TYPE getCmdType();
@@ -38,7 +32,7 @@ private:
 	// stoul에서 변환 실패 시 std::invalid_argument 예외, 범위 초과 시 std::out_of_range 예외를 발생
 	unsigned long parseHexAddress(const std::string& hexAddress);
 
-	CMD_TYPE eCmd = NONE_CMD;
+	CMD_TYPE eCmd = CMD_INVALID;
 	int nAddr = -1;
 	int nSize = -1;
 	string dwData = "";

--- a/SSD/ArgumentParser_test.cpp
+++ b/SSD/ArgumentParser_test.cpp
@@ -19,7 +19,7 @@ TEST_F(ArgumentParserFixture, ReadCommandTest) {
 
 	parser.parse_args(3, argv);
 
-	EXPECT_EQ(ArgumentParser::READ_CMD, parser.getCmdType());
+	EXPECT_EQ(CMD_READ, parser.getCmdType());
 	EXPECT_EQ(10, parser.getAddr());
 }
 
@@ -52,7 +52,7 @@ TEST_F(ArgumentParserFixture, WriteCommandTest) {
 
 	parser.parse_args(4, argv);
 
-	EXPECT_EQ(ArgumentParser::WRITE_CMD, parser.getCmdType());
+	EXPECT_EQ(CMD_WRITE, parser.getCmdType());
 	EXPECT_EQ(20, parser.getAddr());
 	EXPECT_EQ("0xAAAABBBB", parser.getData());
 }

--- a/SSD/global_config.h
+++ b/SSD/global_config.h
@@ -3,6 +3,11 @@
 // SSD
 #define MAX_LBA 99
 #define MIN_LBA 0
+#define CMD_INVALID	0xFFFF
+#define CMD_READ	1
+#define CMD_WRITE	2
+#define CMD_ERASE	3
+#define CMD_FLUSH	4
 
 // ArgumentParser
 #define ARG_IDX_CMD		1

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -34,18 +34,18 @@ void SSD::run(int argc, const char* argv[])
 
 		argumentParser->parse_args(argc, argv);
 		switch (argumentParser->getCmdType()) {
-		case ArgumentParser::READ_CMD: {
+		case CMD_READ: {
 			int addr = argumentParser->getAddr();
 			result = reader->read(addr);
 			break;
 		}
-		case ArgumentParser::WRITE_CMD: {
+		case CMD_WRITE: {
 			int addr = argumentParser->getAddr();
 			string data = argumentParser->getData();
 			writer->write(addr, data);
 			break;
 		}
-		case ArgumentParser::ERASE_CMD: {
+		case CMD_ERASE: {
 			int addr = argumentParser->getAddr();
 			int size = argumentParser->getSize();
 			eraser->erase(addr, size);


### PR DESCRIPTION
패치 내용
- CMD_TYPE을 다른 모듈에서도 사용할 일이 있어, global_config.h로 이동하였습니다.

패치 세부 내용
1. ArgumentParser에 정의되어있던 CMD_TYPE을 global_config.h로 이동


이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
