### PR TITLE
간간히 발생하던 linking 에러 수정

### DIFF
--- a/TestShell/TestShell.vcxproj
+++ b/TestShell/TestShell.vcxproj
@@ -141,7 +141,6 @@
     <ClCompile Include="read_command.cpp" />
     <ClCompile Include="shell.cpp" />
     <ClCompile Include="ssd_impl.cpp" />
-    <ClCompile Include="ssd_impl.h" />
     <ClCompile Include="test_command.cpp" />
     <ClCompile Include="test_logger.cpp" />
     <ClCompile Include="test_command_parser.cpp" />
@@ -154,13 +153,14 @@
     <ClCompile Include="test_with_real_ssd.cpp" />
     <ClCompile Include="write_command.cpp" />
     <ClCompile Include="write_read_aging_command.cpp" />
-    <ClCompile Include="write_read_aging_command.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="command_factory.h" />
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="ssd_impl.h" />
+    <ClInclude Include="write_read_aging_command.h" />
     <ClInclude Include="command.h" />
     <ClInclude Include="command_factory_complex.h" />
     <ClInclude Include="command_list.h" />

--- a/TestShell/test_command.cpp
+++ b/TestShell/test_command.cpp
@@ -1,3 +1,4 @@
+#ifdef _DEBUG
 #include "gmock/gmock.h"
 #include <string>
 #include <vector>
@@ -58,3 +59,4 @@ TEST_F(CommandFactoryTest, fullread) {
 	EXPECT_TRUE(command->getNumOfArgs() == 0);
 	EXPECT_EQ("fullread", command->getCmdName());
 }
+#endif

--- a/TestShell/test_command_parser.cpp
+++ b/TestShell/test_command_parser.cpp
@@ -1,8 +1,9 @@
+#ifdef _DEBUG
 #include "gmock/gmock.h"
 #include <string>
 #include <vector>
 #include "command_parser.h"
-
+#include "command_list.h"
 using namespace testing;
 using std::string;
 using std::vector;
@@ -73,3 +74,4 @@ TEST(CommandParserTest, InValidCommand) {
 	string inputCommand = "R 0";
 	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), TestScriptFailExcpetion);
 }
+#endif

--- a/TestShell/test_logger.cpp
+++ b/TestShell/test_logger.cpp
@@ -1,3 +1,4 @@
+#ifdef _DEBUG
 #include <fstream>
 #include <string>
 #include <sstream>
@@ -5,6 +6,7 @@
 
 #include "gmock/gmock.h"
 #include "logger.h"
+
 
 namespace {
 	const std::string TEST_LOG_FILE = "latest.log";
@@ -144,3 +146,4 @@ TEST_F(LoggerTest, DISABLED_AppendLogsOver30KB) {
 	EXPECT_EQ(expect_until, getNumOfFiles("until_", ".log"));
 	EXPECT_EQ(expect_zip, getNumOfFiles("until_", ".zip"));
 }
+#endif

--- a/TestShell/test_with_mock.cpp
+++ b/TestShell/test_with_mock.cpp
@@ -1,3 +1,4 @@
+#ifdef _DEBUG
 #include "gmock/gmock.h"
 #include "ssd_interface.h"
 #include <string>
@@ -188,3 +189,4 @@ TEST_F(TestShellFixtureWithMock, WriteReadAgingCommand) {
 
 	command->run(runner);
 }
+#endif

--- a/TestShell/test_with_real_ssd.cpp
+++ b/TestShell/test_with_real_ssd.cpp
@@ -1,3 +1,4 @@
+#ifdef _DEBUG
 #include "gmock/gmock.h"
 #include "ssd_interface.h"
 #include <string>
@@ -51,3 +52,4 @@ TEST_F(TestShellFixtureWithReal, CmdRunnerRealReadFail) {
 
 	readCommand->run(runner);
 }
+#endif


### PR DESCRIPTION
패치 내용
- 간간히 발생하던 linking 에러 수정
패치 세부 내용
1. header 가 compile 대상으로 넘어가있어 생겼던 것으로 추측합니다.
2. Test 코드들은 전부 Debug모드때만 빌드하도록 수정합니다.
3.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
