### PR TITLE
buffer 로직 개선

### DIFF
--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -17,7 +17,7 @@ void BufferManager::init() {
 bool BufferManager::existBufferFile(int buf_idx)
 {
 	string dir_path = BUFFER_DIR_NAME "\\*";
-	string empty_file_name = string(getBufferFilePrefix(buf_idx)) + BUFFER_NAME_EMPTY;
+	string empty_file_name = getBufferFilePrefix(buf_idx) + BUFFER_NAME_EMPTY;
 	if (fileHandler->isExist(dir_path, empty_file_name)) return false;
 
 	string file_name = getBufferFilePrefix(buf_idx);
@@ -27,24 +27,17 @@ bool BufferManager::existBufferFile(int buf_idx)
 
 void BufferManager::createBufferFile(int buf_idx)
 {
-	string file_name = string(getBufferFilePrefix(buf_idx)) + BUFFER_NAME_EMPTY;
+	string file_name = getBufferFilePrefix(buf_idx) + BUFFER_NAME_EMPTY;
 	string file_path = BUFFER_DIR_NAME "\\";
 	file_path += file_name;
 	fileHandler->createEmptyFile(file_path);
-	fillBufferInfo(file_name, buf_idx, false);
+	fillBufferInfo(file_name, buf_idx);
 	return;
 }
 
-const char* BufferManager::getBufferFilePrefix(int buf_idx)
+string BufferManager::getBufferFilePrefix(int buf_idx)
 {
-	switch (buf_idx) {
-	case 0: return PREFIX_BUFFER_FILE1;
-	case 1: return PREFIX_BUFFER_FILE2;
-	case 2: return PREFIX_BUFFER_FILE3;
-	case 3: return PREFIX_BUFFER_FILE4;
-	case 4: return PREFIX_BUFFER_FILE5;
-	default: return "";
-	}
+	return std::to_string(buf_idx+1) + "_";
 }
 
 void BufferManager::updateBufferState(int buf_idx)
@@ -53,7 +46,7 @@ void BufferManager::updateBufferState(int buf_idx)
 
 	if (buffer_fname.size() > 1) throw std::exception("There are many buffer files in same prefix.");
 
-	fillBufferInfo(buffer_fname.front(), buf_idx, false);
+	fillBufferInfo(buffer_fname.front(), buf_idx);
 	IncreaseBufferCnt();
 
 	updateInternalBufferState();
@@ -61,34 +54,41 @@ void BufferManager::updateBufferState(int buf_idx)
 
 void BufferManager::updateInternalBufferState()
 {
-	for (int buffer_idx = 0; buffer_idx < BUFFER_SIZE; buffer_idx++) {
-		if (buffers[buffer_idx].cmd == INVALID_VALUE) continue;
-		else if (buffers[buffer_idx].cmd == CMD_WRITE) {
-			int lba = buffers[buffer_idx].lba;
-			const string& data = buffers[buffer_idx].written_data;
-			internalBuffers[lba].cmd = CMD_WRITE;
-			internalBuffers[lba].data = data;
+	for (int buf_idx = 0; buf_idx < BUFFER_SIZE; buf_idx++) {
+		if (buffers[buf_idx].cmd == INVALID_VALUE) continue;
+		else if (buffers[buf_idx].cmd == CMD_WRITE) {
+			fillInternalBufferWrite(buf_idx);
 		}
-		else if (buffers[buffer_idx].cmd == CMD_ERASE) {
-			int lba = buffers[buffer_idx].lba;
-			int size = buffers[buffer_idx].erase_size;
-			for (int count = 0; count < size; count++) {
-				internalBuffers[lba + count].cmd = CMD_ERASE;
-				internalBuffers[lba + count].data = ERASED_VALUE;
-			}
+		else if (buffers[buf_idx].cmd == CMD_ERASE) {
+			fillInternalBufferErase(buf_idx);
 		}
 	}
 }
 
-void BufferManager::fillBufferInfo(string fname, int buf_idx, bool need_file_change)
+void BufferManager::fillInternalBufferErase(int buf_idx)
+{
+	int lba = buffers[buf_idx].lba;
+	int size = buffers[buf_idx].erase_size;
+	for (int count = 0; count < size; count++) {
+		internalBuffers[lba + count].cmd = CMD_ERASE;
+		internalBuffers[lba + count].data = NAND_DATA_EMPTY;
+	}
+}
+
+void BufferManager::fillInternalBufferWrite(int buf_idx)
+{
+	int lba = buffers[buf_idx].lba;
+	const string& data = buffers[buf_idx].written_data;
+	internalBuffers[lba].cmd = CMD_WRITE;
+	internalBuffers[lba].data = data;
+}
+
+void BufferManager::fillBufferInfo(string fname, int buf_idx)
 {
 	if (buf_idx < 0 || buf_idx >= BUFFER_SIZE) throw std::exception("invalid buffer index.");
 
 	std::smatch m;
 	std::regex writeRegex(R"([1-5]_W_([0-9]*)_(0x[0-9A-Fa-f]+))");
-	std::regex eraseRegex(R"([1-5]_E_([0-9]*)_([0-9]+))");
-	string old_name = buffers[buf_idx].fname;
-
 	if (std::regex_search(fname, m, writeRegex)) {
 		setBufferInfo(buf_idx,
 			fname,
@@ -96,14 +96,18 @@ void BufferManager::fillBufferInfo(string fname, int buf_idx, bool need_file_cha
 			std::atoi(m.str(1).c_str())/*LBA*/,
 			m.str(2)/*data*/,
 			INVALID_VALUE/*erase size*/);
+		return;
 	}
-	else if (std::regex_search(fname, m, eraseRegex)) {
+
+	std::regex eraseRegex(R"([1-5]_E_([0-9]*)_([0-9]+))");
+	if (std::regex_search(fname, m, eraseRegex)) {
 		setBufferInfo(buf_idx,
 			fname,
 			CMD_ERASE,
 			std::atoi(m.str(1).c_str())/*LBA*/,
 			""/*data*/,
 			std::atoi(m.str(2).c_str())/*erase size*/);
+		return;
 	}
 	else {
 		setBufferInfo(buf_idx,
@@ -112,11 +116,7 @@ void BufferManager::fillBufferInfo(string fname, int buf_idx, bool need_file_cha
 			INVALID_VALUE,
 			"",
 			INVALID_VALUE);
-	}
-
-	if (need_file_change)
-	{
-		writeBuffer(old_name, fname);
+		return;
 	}
 }
 
@@ -150,7 +150,7 @@ void BufferManager::updateBuffer() {
 	bool meetErase = false;
 	vector<int> write_lbas;
 
-	int buffer_idx = 0;
+	int buf_idx = 0;
 	for (int internalBufferIdx = 0; internalBufferIdx < 100; internalBufferIdx++) {
 		InternalBufferInfo& internalBuffer = internalBuffers[internalBufferIdx];
 		if (meetErase == false) {
@@ -160,8 +160,8 @@ void BufferManager::updateBuffer() {
 				write_lbas.clear();
 			}
 			else if (internalBuffer.cmd == CMD_WRITE) {
-				fillWriteBufferInfo(internalBufferIdx, buffer_idx);
-				buffer_idx++;
+				fillWriteBufferInfo(internalBufferIdx, buf_idx);
+				buf_idx++;
 			}
 		}
 		else {
@@ -171,56 +171,74 @@ void BufferManager::updateBuffer() {
 			}
 			else if (internalBuffer.cmd == INVALID_VALUE) {
 				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
-				int erase_count = internalBufferIdx - eraseStartLBA - 1;
-				fillEraseBufferInfo(buffer_idx, eraseStartLBA, erase_count);
-				buffer_idx++;
+				int erase_count = internalBufferIdx - eraseStartLBA;
+				fillEraseBufferInfo(buf_idx, eraseStartLBA, erase_count);
+				buf_idx++;
 				for (int write_lba : write_lbas) {
-					fillWriteBufferInfo(write_lba, buffer_idx);
-					buffer_idx++;
+					fillWriteBufferInfo(write_lba, buf_idx);
+					buf_idx++;
 				}
 				meetErase = false;
 			}
 
-			else if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 10) {
+			else if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
 				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
-				int erase_count = internalBufferIdx - eraseStartLBA;
-				fillEraseBufferInfo(buffer_idx, eraseStartLBA, erase_count);
-				buffer_idx++;
+				int erase_count = internalBufferIdx - eraseStartLBA + 1;
+				fillEraseBufferInfo(buf_idx, eraseStartLBA, erase_count);
+				buf_idx++;
 				for (int write_lba : write_lbas) {
-					fillWriteBufferInfo(write_lba, buffer_idx);
-					buffer_idx++;
+					fillWriteBufferInfo(write_lba, buf_idx);
+					buf_idx++;
 				}
 				meetErase = false;
 			}
 		}
 	}
-	valid_buf_cnt = buffer_idx;
-	for (; buffer_idx < BUFFER_SIZE; buffer_idx++) {
+	valid_buf_cnt = buf_idx;
+	for (; buf_idx < BUFFER_SIZE; buf_idx++) {
 		// empty Buffer도 기록합니다.
-		fillEmptyBufferInfo(buffer_idx);
+		fillEmptyBufferInfo(buf_idx);
 	}
 }
-void BufferManager::fillEmptyBufferInfo(int buffer_idx)
-{
+
+string BufferInfo::getFileName(int buf_idx) {
 	std::ostringstream oss;
-	oss << buffer_idx + 1 << "_empty";
-	fillBufferInfo(oss.str(), buffer_idx, true);
+	if (cmd == INVALID_VALUE) {
+		oss << buf_idx + 1 << "_empty";
+	}
+	else if (cmd == CMD_WRITE) {
+		oss << buf_idx + 1 << "_W_" << lba << "_" << written_data;
+	}
+	else if (cmd == CMD_ERASE) {
+		oss << buf_idx + 1 << "_E_" << lba << "_" << erase_size;
+	}
+	return oss.str();
 }
-void BufferManager::fillWriteBufferInfo(int write_lba, int buffer_idx)
+
+void BufferManager::fillEmptyBufferInfo(int buf_idx)
 {
+	string old_name = buffers[buf_idx].getFileName(buf_idx);
+	setBufferInfo(buf_idx, "", INVALID_VALUE, INVALID_VALUE, "", INVALID_VALUE);
+	string new_name = buffers[buf_idx].getFileName(buf_idx);
+	writeBuffer(old_name, new_name);
+}
+void BufferManager::fillWriteBufferInfo(int write_lba, int buf_idx)
+{
+	string old_name = buffers[buf_idx].getFileName(buf_idx);
 	string data = internalBuffers[write_lba].data;
-	std::ostringstream oss;
-	oss << buffer_idx + 1 << "_W_" << write_lba << "_" << data;
-	fillBufferInfo(oss.str(), buffer_idx, true);
+	setBufferInfo(buf_idx, "", CMD_WRITE, write_lba, data, INVALID_VALUE);
+	string new_name = buffers[buf_idx].getFileName(buf_idx);
+	writeBuffer(old_name, new_name);
 }
-void BufferManager::fillEraseBufferInfo(int buffer_idx, int erase_start, int erase_count)
+void BufferManager::fillEraseBufferInfo(int buf_idx, int erase_start, int erase_count)
 {
-	std::ostringstream oss;
-	oss << buffer_idx + 1 << "_E_" << erase_start << "_" << erase_count;
-	fillBufferInfo(oss.str(), buffer_idx, true);
+	string old_name = buffers[buf_idx].getFileName(buf_idx);
+	setBufferInfo(buf_idx, "", CMD_ERASE, erase_start, "", erase_count);
+	string new_name = buffers[buf_idx].getFileName(buf_idx);
+	writeBuffer(old_name, new_name);
 }
 void BufferManager::addWriteCommand(int lba, const string& data) {
-	if (data == ERASED_VALUE) {
+	if (data == NAND_DATA_EMPTY) {
 		addEraseCommand(lba, 1);
 		return;
 	}
@@ -236,7 +254,7 @@ void BufferManager::addEraseCommand(int lba, int count) {
 		flush();
 	}
 	for (int i = lba; i < lba + count; i++) {
-		internalBuffers[i] = { CMD_ERASE, ERASED_VALUE };
+		internalBuffers[i] = { CMD_ERASE, NAND_DATA_EMPTY };
 	}
 	updateBuffer();
 }
@@ -256,8 +274,7 @@ void BufferManager::flush() {
 	// 외부 버퍼 초기화
 	int buf_cnt = getUsedBufferCount();
 	for (int buf_idx = 0; buf_idx < buf_cnt; buf_idx++) {
-		string file_name = string(getBufferFilePrefix(buf_idx)) + BUFFER_NAME_EMPTY;
-		fillBufferInfo(file_name, buf_idx, true);
+		fillEmptyBufferInfo(buf_idx);
 	}
 	nandFlashMemory->write(datas);
 	valid_buf_cnt = 0;
@@ -272,6 +289,9 @@ void BufferManager::initInternalBuffers()
 }
 
 void BufferManager::writeBuffer(const string& old_name, const string& new_name) {
+	if (old_name == new_name){
+		return;
+	}
 	string old_path = BUFFER_DIR_NAME "\\";
 	old_path += old_name;
 	string new_path = BUFFER_DIR_NAME "\\";

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -20,8 +20,19 @@ public:
 		int erase_size;
 	};
 
+	struct InternalBufferInfo {
+		CMD_TYPE cmd;
+		string data;
+	};
+
 	BufferManager(NandFlashMemory* nandFlashMemory, FileHandler* fileHandler)
 		: nandFlashMemory{ nandFlashMemory }, fileHandler{ fileHandler } {
+
+		// 내부 버퍼 초기화
+		for (int index = 0; index < 100; index++) {
+			internalBuffers[index].cmd = INVALID_VALUE;
+			internalBuffers[index].data = "";
+		}
 	}
 
 	void init();
@@ -47,6 +58,7 @@ private:
 	NandFlashMemory* nandFlashMemory;
 	FileHandler* fileHandler;
 	vector<BufferInfo> buffers{ BUFFER_SIZE };
+	vector<InternalBufferInfo> internalBuffers{ 100 };
 	int valid_buf_cnt{ 0 };
 
 	// Buffer 파일 존재 여부를 반환합니다.
@@ -81,4 +93,6 @@ private:
 	void IncreaseBufferCnt();
 
 	void DecreaseBufferCnt();
+
+	void updateBuffer();
 };

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -9,17 +9,19 @@
 using std::string;
 using std::vector;
 
+struct BufferInfo
+{
+	string fname;
+	CMD_TYPE cmd;
+	int lba;
+	string written_data;
+	int erase_size;
+
+	string getFileName(int buf_idx);
+};
+
 class BufferManager {
 public:
-	struct BufferInfo
-	{
-		string fname;
-		CMD_TYPE cmd;
-		int lba;
-		string written_data;
-		int erase_size;
-	};
-
 	struct InternalBufferInfo {
 		CMD_TYPE cmd;
 		string data;
@@ -51,7 +53,6 @@ public:
 	// empty가 아닌 버퍼의 개수를 리턴합니다.
 	int getUsedBufferCount();
 private:
-	const string ERASED_VALUE = "0x00000000";
 	NandFlashMemory* nandFlashMemory;
 	FileHandler* fileHandler;
 	vector<BufferInfo> buffers{ BUFFER_SIZE };
@@ -65,14 +66,18 @@ private:
 	void createBufferFile(int buf_idx);
 
 	// Buffer 파일의 Prefix 매크로 반환합니다.
-	const char* getBufferFilePrefix(int buf_idx);
+	string getBufferFilePrefix(int buf_idx);
 
 	// 버퍼 상태 업데이트
 	void updateBufferState(int buf_idx);
 
 	void updateInternalBufferState();
 
-	void fillBufferInfo(string fname, int buf_idx, bool need_file_change);
+	void fillInternalBufferErase(int buffer_idx);
+
+	void fillInternalBufferWrite(int buffer_idx);
+
+	void fillBufferInfo(string fname, int buf_idx);
 
 	void setBufferInfo(
 		int buf_idx,

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -28,11 +28,7 @@ public:
 	BufferManager(NandFlashMemory* nandFlashMemory, FileHandler* fileHandler)
 		: nandFlashMemory{ nandFlashMemory }, fileHandler{ fileHandler } {
 
-		// 내부 버퍼 초기화
-		for (int index = 0; index < 100; index++) {
-			internalBuffers[index].cmd = INVALID_VALUE;
-			internalBuffers[index].data = "";
-		}
+		initInternalBuffers();
 	}
 
 	void init();
@@ -55,6 +51,7 @@ public:
 	// empty가 아닌 버퍼의 개수를 리턴합니다.
 	int getUsedBufferCount();
 private:
+	const string ERASED_VALUE = "0x00000000";
 	NandFlashMemory* nandFlashMemory;
 	FileHandler* fileHandler;
 	vector<BufferInfo> buffers{ BUFFER_SIZE };
@@ -72,6 +69,8 @@ private:
 
 	// 버퍼 상태 업데이트
 	void updateBufferState(int buf_idx);
+
+	void updateInternalBufferState();
 
 	void fillBufferInfo(string fname, int buf_idx, bool need_file_change);
 
@@ -92,7 +91,10 @@ private:
 
 	void IncreaseBufferCnt();
 
-	void DecreaseBufferCnt();
-
 	void updateBuffer();
+
+	void initInternalBuffers();
+	void fillEmptyBufferInfo(int buffer_idx);
+	void fillWriteBufferInfo(int write_lba, int buffer_idx);
+	void fillEraseBufferInfo(int buffer_idx, int erase_start, int erase_count);
 };

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -11,7 +11,6 @@ using std::vector;
 
 struct BufferInfo
 {
-	string fname;
 	CMD_TYPE cmd;
 	int lba;
 	string written_data;
@@ -79,9 +78,16 @@ private:
 
 	void fillBufferInfo(string fname, int buf_idx);
 
+	void setEmptyBufferInfo(int buf_idx, const string& fname);
+
+	void setEraseBufferInfo(int buf_idx, const string& fname);
+
+	void setWriteBufferInfo(int buf_idx, const string& fname);
+
+	CMD_TYPE getBufferTypeFromFilenames(const string& fname);
+
 	void setBufferInfo(
 		int buf_idx,
-		string fname,
 		CMD_TYPE cmd,
 		int lba,
 		string written_data,

--- a/SSD/buffer_manager_test.cpp
+++ b/SSD/buffer_manager_test.cpp
@@ -117,7 +117,7 @@ TEST_F(BufferManagerFixture, TC3) {
 	EXPECT_EQ(1, manager.getUsedBufferCount());
 }
 
-TEST_F(BufferManagerFixture, DISABLED_TC4) {
+TEST_F(BufferManagerFixture, TC4) {
 	manager.addEraseCommand(0, 3);
 	manager.addEraseCommand(3, 3);
 
@@ -125,7 +125,7 @@ TEST_F(BufferManagerFixture, DISABLED_TC4) {
 	EXPECT_EQ(1, manager.getUsedBufferCount());
 }
 
-TEST_F(BufferManagerFixture, DISABLED_TC5) {
+TEST_F(BufferManagerFixture, TC5) {
 	manager.addEraseCommand(0, 3);
 	manager.addWriteCommand(3, "0x00000000");
 
@@ -133,7 +133,7 @@ TEST_F(BufferManagerFixture, DISABLED_TC5) {
 	EXPECT_EQ(1, manager.getUsedBufferCount());
 }
 
-TEST_F(BufferManagerFixture, DISABLED_TC6) {
+TEST_F(BufferManagerFixture, TC6) {
 	manager.addWriteCommand(1, "0x11112222");
 	manager.addWriteCommand(10, "0xFAFAFAFA");
 	manager.addWriteCommand(1, "0x0000DDDD");
@@ -146,7 +146,7 @@ TEST_F(BufferManagerFixture, DISABLED_TC6) {
 }
 
 
-TEST_F(BufferManagerFixture, DISABLED_TC7) {
+TEST_F(BufferManagerFixture, TC7) {
 	manager.addWriteCommand(3, "0x11112222");
 	manager.addEraseCommand(0, 5);
 	manager.addWriteCommand(4, "0x22224444");
@@ -155,7 +155,7 @@ TEST_F(BufferManagerFixture, DISABLED_TC7) {
 	EXPECT_EQ(2, manager.getUsedBufferCount());
 }
 
-TEST_F(BufferManagerFixture, DISABLED_TC8) {
+TEST_F(BufferManagerFixture, TC8) {
 	manager.addEraseCommand(0, 2);
 	manager.addWriteCommand(2, "0x11112222");
 	manager.addEraseCommand(3, 2);
@@ -174,11 +174,11 @@ TEST_F(BufferManagerFixture, TC9) {
 	EXPECT_EQ(3, manager.getUsedBufferCount());
 }
 
-TEST_F(BufferManagerFixture, DISABLED_TC10) {
+TEST_F(BufferManagerFixture, TC10) {
 	manager.addEraseCommand(0, 3);
 	manager.addWriteCommand(1, "0x11111111");
 	manager.addWriteCommand(2, "0x22222222");
-	manager.addWriteCommand(3, "0ㅌ3333333");
+	manager.addWriteCommand(0, "0x33333333");
 
 	// E 0 3 이 이후에 들어온 W 명령어들에 의해 지워집니다.
 	EXPECT_EQ(3, manager.getUsedBufferCount());

--- a/SSD/global_config.h
+++ b/SSD/global_config.h
@@ -33,11 +33,6 @@
 #define BUFFER_ENABLE true
 #define BUFFER_DIR_NAME	"buffer"
 #define BUFFER_SIZE 5
-#define PREFIX_BUFFER_FILE1	"1_"
-#define PREFIX_BUFFER_FILE2	"2_"
-#define PREFIX_BUFFER_FILE3	"3_"
-#define PREFIX_BUFFER_FILE4	"4_"
-#define PREFIX_BUFFER_FILE5	"5_"
 #define BUFFER_NAME_EMPTY	"empty"
 
 typedef int CMD_TYPE;


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1. 모든 buffer TC를 통과하도록 로직을 개선했습니다.
2. 내부적으로 lba 100개 각각에 대한 internal buffer 를 만들어 놓고 아래와 같이 수행합니다.
 
1. buffer file을 보고 internal Buffer를 업데이트 합니다.
2. write 나 erase 명령이 들어오면 internal Buffer를 업데이트합니다.
3. 2 이후에 internal Buffer를 보고 buffer file을 새로 작성합니다.

이 부분은 중점적으로 봐주세요
- 로직에 대한 디테일한 설명은 오프라인에서 설명 드리겠습니다.

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
