### PR TITLE
SSD argument 예외처리 추가 및 Unittest 추가

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -146,6 +146,7 @@
     <ClCompile Include="output_handler.cpp" />
     <ClCompile Include="output_handler_test.cpp" />
     <ClCompile Include="ssd_command.cpp" />
+    <ClCompile Include="ssd_command_test.cpp" />
     <ClCompile Include="write_command.cpp" />
     <ClCompile Include="write_command_test.cpp" />
     <ClCompile Include="ssd.cpp" />

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -21,12 +21,6 @@
     <ClCompile Include="main.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
-      <Filter>소스 파일</Filter>
-    </ClCompile>
     <ClCompile Include="read_command_test.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
@@ -80,6 +74,9 @@
     </ClCompile>
     <ClCompile Include="file_handler_test.cpp">
       <Filter>테스트 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ssd_command_test.cpp">
+      <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/SSD/erase_command.cpp
+++ b/SSD/erase_command.cpp
@@ -1,12 +1,24 @@
+#include <string>
 #include "erase_command.h"
+
+using std::string;
+using std::stoi;
+
+bool EraseCommand::isInvalidNumber(const string& str) {
+	return (str.find_first_not_of("0123456789") != string::npos);
+}
 
 void EraseCommand::parseArg(int argc, const char* argv[])
 {
 	if (argc != ERASE_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
-	startLBA = atoi(argv[ARG_IDX_ERASE_START_ADDR]);
-	count = atoi(argv[ARG_IDX_ERASE_COUNT]);
-	if (isInvalidAddress()) throw std::invalid_argument("Out of range");
 
+	if (isInvalidNumber(string(argv[ARG_IDX_ERASE_START_ADDR]))) throw std::invalid_argument("Not a number in address");
+	startLBA = stoi(argv[ARG_IDX_ERASE_START_ADDR]);
+
+	if (isInvalidNumber(string(argv[ARG_IDX_ERASE_COUNT]))) throw std::invalid_argument("Not a number in count");
+	count = stoi(argv[ARG_IDX_ERASE_COUNT]);
+
+	if (isInvalidAddress()) throw std::invalid_argument("Out of range");
 	if (isInvalidEraseCount()) throw std::invalid_argument("Invalid erase LBA count");
 	if (isInvalidEraseRange()) throw std::invalid_argument("The erase range exceeds the MAX_LBA");
 }

--- a/SSD/erase_command.h
+++ b/SSD/erase_command.h
@@ -19,7 +19,7 @@ public:
 	void erase(int lba, int size);
 
 private:
-
+	bool isInvalidNumber(const string& str);
 	bool isInvalidAddress();
 	bool isInvalidEraseCount();
 	bool isInvalidEraseRange();

--- a/SSD/read_command.cpp
+++ b/SSD/read_command.cpp
@@ -1,11 +1,18 @@
 #include "read_command.h"
 
 using std::string;
+using std::stoi;
+
+bool ReadCommand::isInvalidNumber(const string& str) {
+	return (str.find_first_not_of("0123456789") != string::npos);
+}
 
 void ReadCommand::parseArg(int argc, const char* argv[])
 {
 	if (argc != READ_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
-	lba = atoi(argv[ARG_IDX_ADDR]);
+
+	if (isInvalidNumber(string(argv[ARG_IDX_ADDR]))) throw std::invalid_argument("Not a number in address");
+	lba = stoi(argv[ARG_IDX_ADDR]);
 	if (isInvalidAddress()) throw std::invalid_argument("Out of range");
 }
 

--- a/SSD/read_command.h
+++ b/SSD/read_command.h
@@ -18,6 +18,7 @@ public:
 
 private:
 	bool isInvalidAddress();
+	bool isInvalidNumber(const string& str);
 
 	NandFlashMemory* nandFlashMemory;
 	BufferManager* bufferManager;

--- a/SSD/ssd_command.cpp
+++ b/SSD/ssd_command.cpp
@@ -8,8 +8,6 @@ using std::string;
 
 SSDCommand* SSDCommandFactory::createCommand(const string& cmdName, NandFlashMemory* nandFlashMemory, BufferManager* bufferManager)
 {
-
-
 	if (isReadCmd(cmdName)) return new ReadCommand(nandFlashMemory, bufferManager);
 	else if (isWriteCmd(cmdName)) return new WriteCommand(nandFlashMemory, bufferManager);
 	else if (isEraseCmd(cmdName)) return new EraseCommand(nandFlashMemory, bufferManager);

--- a/SSD/ssd_command_test.cpp
+++ b/SSD/ssd_command_test.cpp
@@ -8,9 +8,9 @@
 
 using ::testing::Test;
 
-class SSDCommandTextFixture : public Test {
+class SSDCommandTestFixture : public Test {
 public:
-	SSDCommandTextFixture() {
+	SSDCommandTestFixture() {
 		// Create result IO instance
 		FileHandler* fileHandler = new FileHandler();
 		OutputHandler* outputHandler = new OutputHandler(fileHandler);
@@ -33,7 +33,7 @@ public:
 	SSDCommandFactory* factory;
 };
 
-TEST_F(SSDCommandTextFixture, ReadCommandOutOfRangeTest) {
+TEST_F(SSDCommandTestFixture, ReadCommandOutOfRangeTest) {
 	// Arrange
 	const char* argv[] = {
 		"ssd.exe",
@@ -57,7 +57,7 @@ TEST_F(SSDCommandTextFixture, ReadCommandOutOfRangeTest) {
 	}
 }
 
-TEST_F(SSDCommandTextFixture, ReadCommandInvalidAddrTest) {
+TEST_F(SSDCommandTestFixture, ReadCommandInvalidAddrTest) {
 	// Arrange
 	const char* argv[] = {
 		"ssd.exe",
@@ -81,7 +81,7 @@ TEST_F(SSDCommandTextFixture, ReadCommandInvalidAddrTest) {
 	}
 }
 
-TEST_F(SSDCommandTextFixture, WriteCommandInvalidHexDataTest) {
+TEST_F(SSDCommandTestFixture, WriteCommandInvalidHexDataTest) {
 	// Arrange
 	const char* argv[] = {
 		"ssd.exe",
@@ -106,7 +106,7 @@ TEST_F(SSDCommandTextFixture, WriteCommandInvalidHexDataTest) {
 	}
 }
 
-TEST_F(SSDCommandTextFixture, EraseCommandInvalidCountTest) {
+TEST_F(SSDCommandTestFixture, EraseCommandInvalidCountTest) {
 	// Arrange
 	const char* argv[] = {
 		"ssd.exe",
@@ -131,7 +131,7 @@ TEST_F(SSDCommandTextFixture, EraseCommandInvalidCountTest) {
 	}
 }
 
-TEST_F(SSDCommandTextFixture, EraseCommandRangeOverTest) {
+TEST_F(SSDCommandTestFixture, EraseCommandRangeOverTest) {
 	// Arrange
 	const char* argv[] = {
 		"ssd.exe",

--- a/SSD/ssd_command_test.cpp
+++ b/SSD/ssd_command_test.cpp
@@ -87,7 +87,7 @@ TEST_F(SSDCommandTestFixture, WriteCommandInvalidHexDataTest) {
 		"ssd.exe",
 		"W",
 		"20",
-		"QQQQZZZZ"
+		"0xQQQQZZZZ"
 	};
 
 	int argc = 4;
@@ -103,6 +103,81 @@ TEST_F(SSDCommandTestFixture, WriteCommandInvalidHexDataTest) {
 	catch (std::invalid_argument e)
 	{
 		EXPECT_EQ("Not a hex number in data", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTestFixture, WriteCommandShortHexDataTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"W",
+		"20",
+		"1000"
+	};
+
+	int argc = 4;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Incorrect Hex number length in data", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTestFixture, WriteCommandIncorrectHexDataTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"W",
+		"20",
+		"0Z1000AAAA"
+	};
+
+	int argc = 4;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Not a hexa digit format in data", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTestFixture, WriteCommandTooLongHexDataTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"W",
+		"30",
+		"0xAAAABBBBCCCC"
+	};
+
+	int argc = 4;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Incorrect Hex number length in data", string(e.what()));
 	}
 }
 

--- a/SSD/ssd_command_test.cpp
+++ b/SSD/ssd_command_test.cpp
@@ -1,0 +1,157 @@
+#include "gmock/gmock.h"
+#include "read_command.h"
+#include "output_handler.h"
+#include "nand_flash_memory.h"
+#include "nand_flash_memory_impl.h"
+#include "buffer_manager.h"
+#include "file_handler.h"
+
+using ::testing::Test;
+
+class SSDCommandTextFixture : public Test {
+public:
+	SSDCommandTextFixture() {
+		// Create result IO instance
+		FileHandler* fileHandler = new FileHandler();
+		OutputHandler* outputHandler = new OutputHandler(fileHandler);
+
+		// Create nand IO instance
+		NandFlashMemoryImpl* nand = new NandFlashMemoryImpl(fileHandler);
+		BufferManager* bufferManager = new BufferManager(nand, fileHandler);
+
+		SSDCommandFactory* factory = new SSDCommandFactory();
+	}
+
+	// Create result IO instance
+	FileHandler* fileHandler;
+	OutputHandler* outputHandler;
+
+	// Create nand IO instance
+	NandFlashMemoryImpl* nand;
+	BufferManager* bufferManager;
+
+	SSDCommandFactory* factory;
+};
+
+TEST_F(SSDCommandTextFixture, ReadCommandOutOfRangeTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"R",
+		"1000"
+	};
+
+	int argc = 3;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Out of range", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTextFixture, ReadCommandInvalidAddrTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"R",
+		"A"
+	};
+
+	int argc = 3;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Not a number in address", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTextFixture, WriteCommandInvalidHexDataTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"W",
+		"20",
+		"QQQQZZZZ"
+	};
+
+	int argc = 4;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Not a hex number in data", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTextFixture, EraseCommandInvalidCountTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"E",
+		"91",
+		"E"
+	};
+
+	int argc = 4;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("Not a number in count", string(e.what()));
+	}
+}
+
+TEST_F(SSDCommandTextFixture, EraseCommandRangeOverTest) {
+	// Arrange
+	const char* argv[] = {
+		"ssd.exe",
+		"E",
+		"91",
+		"10"
+	};
+
+	int argc = 4;
+
+	// Act
+	SSDCommand* cmd = factory->createCommand(string(argv[ARG_IDX_CMD]), nand, bufferManager);
+
+	// Assert
+	try {
+		cmd->parseArg(argc, argv);
+
+	}
+	catch (std::invalid_argument e)
+	{
+		EXPECT_EQ("The erase range exceeds the MAX_LBA", string(e.what()));
+	}
+}

--- a/SSD/write_command.cpp
+++ b/SSD/write_command.cpp
@@ -1,11 +1,13 @@
 ﻿#include "write_command.h"
+using std::string;
+using std::stoi;
 
 void WriteCommand::parseArg(int argc, const char* argv[])
 {
 	if (argc != WRITE_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
 
 	if (isInvalidNumber(string(argv[ARG_IDX_ADDR]))) throw std::invalid_argument("Not a number in address");
-	lba = atoi(argv[ARG_IDX_ADDR]);
+	lba = stoi(argv[ARG_IDX_ADDR]);
 
 	if (isInvalidAddress()) throw std::invalid_argument("Out of range");
 	
@@ -28,14 +30,17 @@ bool WriteCommand::isInvalidAddress() {
 
 void WriteCommand::validDataOrThrow()
 {
-	// "0x" 접두사를 제거 (std::stoul은 자동으로 처리하지만, 명시적으로 제거해도 무방)
+	// 0xAAAABBBB : acceptable hexa digit
+
+	if (data.length() != 10) throw std::invalid_argument("Incorrect Hex number length in data");
+
 	std::string cleanedAddress = data;
+
 	if (cleanedAddress.length() > 2 && (cleanedAddress.substr(0, 2) == "0x" || cleanedAddress.substr(0, 2) == "0X")) {
 		cleanedAddress = cleanedAddress.substr(2);
+		if (isInvalidHexNumber(cleanedAddress)) throw std::invalid_argument("Not a hex number in data");
 	}
-	
-	if (isInvalidHexNumber(cleanedAddress)) throw std::invalid_argument("Not a hex number in data");
-	std::stoul(cleanedAddress, nullptr, 16);
+	else throw std::invalid_argument("Not a hexa digit format in data");
 }
 
 string WriteCommand::run()

--- a/SSD/write_command.cpp
+++ b/SSD/write_command.cpp
@@ -3,12 +3,22 @@
 void WriteCommand::parseArg(int argc, const char* argv[])
 {
 	if (argc != WRITE_CORRECT_ARG_SIZE) throw std::invalid_argument("number of argument is incorrect");
+
+	if (isInvalidNumber(string(argv[ARG_IDX_ADDR]))) throw std::invalid_argument("Not a number in address");
 	lba = atoi(argv[ARG_IDX_ADDR]);
 
 	if (isInvalidAddress()) throw std::invalid_argument("Out of range");
 	
 	data = argv[ARG_IDX_DATA];
 	validDataOrThrow();
+}
+
+bool WriteCommand::isInvalidNumber(const string& str) {
+	return (str.find_first_not_of("0123456789") != string::npos);
+}
+
+bool WriteCommand::isInvalidHexNumber(const string& str) {
+	return (str.find_first_not_of("0123456789ABCDEF") != string::npos);
 }
 
 bool WriteCommand::isInvalidAddress() {
@@ -23,7 +33,8 @@ void WriteCommand::validDataOrThrow()
 	if (cleanedAddress.length() > 2 && (cleanedAddress.substr(0, 2) == "0x" || cleanedAddress.substr(0, 2) == "0X")) {
 		cleanedAddress = cleanedAddress.substr(2);
 	}
-	// 16진수 파싱이 되지 않으면 내부적으로 exception 이 발생합니다. 
+	
+	if (isInvalidHexNumber(cleanedAddress)) throw std::invalid_argument("Not a hex number in data");
 	std::stoul(cleanedAddress, nullptr, 16);
 }
 

--- a/SSD/write_command.h
+++ b/SSD/write_command.h
@@ -17,6 +17,8 @@ public:
 	void parseArg(int argc, const char* argv[]) override;
 	string run() override;
 private:
+	bool isInvalidNumber(const string& str);
+	bool isInvalidHexNumber(const string& str);
 	bool isInvalidAddress();
 	void validDataOrThrow();
 


### PR DESCRIPTION
패치 내용
- SSD argument 예외처리 추가 및 Unittest 추가
패치 세부 내용
1. read command address 에 문자가 들어오는 경우 예외 처리
2. write command data가 hex 값이 아닌 경우 예외 처리
3. write command data가 0xAAAABBBB 같은 0x 가 붙은 8자리 hexa digit이 아닌 경우 error 처리
4. unittest 추가

이 부분은 중점적으로 봐주세요
- 예외처리에서 빠진 부분이 있을 수 있는 지 확인 부탁드립니다.

Check lists
- [X] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [X] Unit Test 100% 통과 확인 (master branch 기준)
- [X] 이상한 파일이 들어가지 않았는지 확인
