### PR TITLE
Test shell/fix command arg size check

### DIFF
--- a/TestShell/TEST_SHELL_CONFIG.h
+++ b/TestShell/TEST_SHELL_CONFIG.h
@@ -59,3 +59,4 @@ const std::string ERROR = "ERROR";
 const std::string DONE = "DONE";
 const std::string FAIL = "FAIL";
 const std::string WRITESUCCESS = "";
+const std::string ERASESUCCESS = "";

--- a/TestShell/erase_command.cpp
+++ b/TestShell/erase_command.cpp
@@ -20,8 +20,13 @@ void EraseCommand::run(const CommandRunner& cmdRunner) const
 void EraseCommand::printResult(const string& result, const string& lba) const
 {
 	std::cout << "[Erase] ";
-	if (result != ERROR)
-		std::cout << "Done" << std::endl << std::endl;
+
+	if (result == ERASESUCCESS) {
+		std::cout << DONE << std::endl;
+	}
+	else {
+		std::cout << FAIL << std::endl;
+	}
 }
 void EraseCommand::printHelp() const
 {

--- a/TestShell/erase_range_command.cpp
+++ b/TestShell/erase_range_command.cpp
@@ -27,11 +27,15 @@ void EraseRangeCommand::run(const CommandRunner& cmdRunner) const
 void EraseRangeCommand::printResult(const string& result, const string& lba) const
 {
 	std::cout << "[EraseRange] ";
+
 	if (result == ERROR) {
-		std::cout << ERROR << std::endl << std::endl;
+		std::cout << ERROR << std::endl;
+	}
+	else if (result == ERASESUCCESS) {
+		std::cout << DONE << std::endl;
 	}
 	else {
-		std::cout << "Done" << std::endl << std::endl;
+		std::cout << FAIL << std::endl;
 	}
 }
 void EraseRangeCommand::printHelp() const
@@ -39,10 +43,10 @@ void EraseRangeCommand::printHelp() const
 	std::cout << "** Erase Range Command **\n";
 	std::cout << " - Erases data from the specified StartLBA to EndLBA SSD.\n\n";
 	std::cout << "Usage\n";
-	std::cout << " erase [StartLBA] [endLBA]\n";
+	std::cout << " erase_range [StartLBA] [endLBA]\n";
 	std::cout << "Example\n";
-	std::cout << " erase 0 9\n";
-	std::cout << " erase 85 99\n";
+	std::cout << " erase_range 0 9\n";
+	std::cout << " erase_range 85 99\n";
 }
 
 std::shared_ptr<Command> EraseRangeCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)

--- a/TestShell/exit_command.cpp
+++ b/TestShell/exit_command.cpp
@@ -24,5 +24,6 @@ void ExitCommand::printHelp() const
 
 std::shared_ptr<Command> ExitCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<ExitCommand>(args);
 }

--- a/TestShell/full_read_command.cpp
+++ b/TestShell/full_read_command.cpp
@@ -36,5 +36,6 @@ void FullReadCommand::printHelp() const
 
 std::shared_ptr<Command> FullReadCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<FullReadCommand>(args);
 }

--- a/TestShell/full_write_and_read_compare_command.cpp
+++ b/TestShell/full_write_and_read_compare_command.cpp
@@ -72,5 +72,6 @@ void FullWriteAndReadCompareCommand::printHelp() const
 std::shared_ptr<Command> FullWriteAndReadCompareCommandFactory::makeCommand(const string& cmdName
 																			, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<FullWriteAndReadCompareCommand>(args);
 }

--- a/TestShell/full_write_command.cpp
+++ b/TestShell/full_write_command.cpp
@@ -48,5 +48,6 @@ void FullWriteCommand::printHelp() const
 
 std::shared_ptr<Command> FullWriteCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<FullWriteCommand>(args);
 }

--- a/TestShell/help_command.cpp
+++ b/TestShell/help_command.cpp
@@ -39,5 +39,6 @@ void HelpCommand::run(const CommandRunner& cmdRunner) const
 
 std::shared_ptr<Command> HelpCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<HelpCommand>(args);
 }

--- a/TestShell/partial_LBA_write_command.cpp
+++ b/TestShell/partial_LBA_write_command.cpp
@@ -51,5 +51,6 @@ void PartialLBAWriteCommand::printHelp() const
 
 std::shared_ptr<Command> PartialLBAWriteCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<PartialLBAWriteCommand>(args);
 }

--- a/TestShell/read_command.cpp
+++ b/TestShell/read_command.cpp
@@ -37,5 +37,6 @@ void ReadCommand::printHelp() const
 
 std::shared_ptr<Command> ReadCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<ReadCommand>(args);
 }

--- a/TestShell/write_command.cpp
+++ b/TestShell/write_command.cpp
@@ -40,5 +40,6 @@ void WriteCommand::printHelp() const
 
 std::shared_ptr<Command> WriteCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<WriteCommand>(args);
 }

--- a/TestShell/write_read_aging_command.cpp
+++ b/TestShell/write_read_aging_command.cpp
@@ -63,5 +63,6 @@ void WriteReadAgingCommand::printHelp() const
 
 std::shared_ptr<Command> WriteReadAgingCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
+	if (args.size() != numOfArgs) return nullptr;
 	return std::make_shared<WriteReadAgingCommand>(args);
 }


### PR DESCRIPTION
패치 내용
- command 객체를 생성하기 전에 각 command factory 에서 argument size를 확인하도록 수정했습니다.
패치 세부 내용
1.
2.
3.

이 부분은 중점적으로 봐주세요
-

Check lists
- [ ] Ctrl + K + D 로 포매팅 확인
- [ ] Build 확인 (master branch 기준)
- [ ] Unit Test 100% 통과 확인 (master branch 기준)
- [ ] 이상한 파일이 들어가지 않았는지 확인
