### PR TITLE
SSD.exe를 찾는 환경추가

### DIFF
--- a/TestShell/ssd_impl.h
+++ b/TestShell/ssd_impl.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <windows.h>
+#include <iostream>
 #include "ssd_interface.h"
 #include <vector>
 
@@ -7,13 +9,30 @@ public:
 	string read(const string& LBA) override;
 	string write(const string& LBA, const string& data) override;
 	string erase(const string& startLBA, const string& range) override;
+	SsdImpl() {
+		string exeEnvVS[2] = { R"(..\x64\Release\SSD.exe)", R"(.\ssd_output.txt)" };
+		string exeEnvEXE[2] = { R"(.\SSD.exe)", R"(.\ssd_output.txt)" };
+
+		if (FileExists(exeEnvVS[0])) {
+			ssdExcutable = exeEnvVS[0];
+			ssdOutputPath = exeEnvVS[1];
+		}
+		else if (FileExists(exeEnvEXE[0])) {
+			ssdExcutable = exeEnvEXE[0];
+			ssdOutputPath = exeEnvEXE[1];
+		}
+		else {
+			throw std::runtime_error("Cannot find SSD.exe");
+		}
+	}
+
 	string flush() override;
 
 	string executeSsd(string ssdCmd);
 	string checkSsdResult();
 private:
-	const string ssdOutputPath = "ssd_output.txt";
-	const string ssdExcutable = R"(..\x64\Release\ssd.exe)";
+	string ssdOutputPath;
+	string ssdExcutable;
 	static const int MAX_ERASE_RANGE = 10;
 
 	string makeReadCommand(const string& LBA);
@@ -22,4 +41,8 @@ private:
 	string makeFlushCommand();
 
 	std::string cmdJoin(std::vector<std::string> const& strings);
+	bool FileExists(const std::string& path) {
+		DWORD attrib = GetFileAttributesA(path.c_str());
+		return (attrib != INVALID_FILE_ATTRIBUTES) && !(attrib & FILE_ATTRIBUTE_DIRECTORY);
+	}
 };


### PR DESCRIPTION
패치 내용
- SSD.exe를 찾는 환경추가
패치 세부 내용
1. VS 에서 실행 시, ../x64/Release/SSD.exe를 실행
2. 명령 프롬프트에서 바로 실행 시, 현재 디렉토리에서 SSD.exe 실행

이 부분은 중점적으로 봐주세요
-

Check lists
- [X] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [X] Unit Test 100% 통과 확인 (master branch 기준)
- [X] 이상한 파일이 들어가지 않았는지 확인
