### PR TITLE
[refac] Shell refactoring 및 Exception 분리

### DIFF
--- a/TestShell/command.h
+++ b/TestShell/command.h
@@ -22,9 +22,9 @@ protected:
 	string cmdName;
 };
 
-class TestScriptFailExcpetion : public std::exception {
+class CommandRunFailException : public std::exception {
 public:
-	TestScriptFailExcpetion(const std::string& msg) : message(msg) {};
+	CommandRunFailException(const std::string& msg) : message(msg) {};
 	const char* what() const noexcept override {
 		return message.c_str();
 	}

--- a/TestShell/command_parser.cpp
+++ b/TestShell/command_parser.cpp
@@ -19,9 +19,7 @@ std::shared_ptr<Command> CommandParser::parseAndMakeShellCommand(const std::stri
 	auto cmd = makeCommand(cmdName, args);
 
 	if (cmd == nullptr)
-		throw TestScriptFailExcpetion("Invalid command");;
-	if (cmd->getNumOfArgs() != args.size())		
-		throw TestScriptFailExcpetion("Invalid arguments");;
+		throw std::invalid_argument("Invalid command");
 
 	return cmd;
 }

--- a/TestShell/full_write_and_read_compare_command.cpp
+++ b/TestShell/full_write_and_read_compare_command.cpp
@@ -24,10 +24,10 @@ void FullWriteAndReadCompareCommand::run(const CommandRunner& cmdRunner) const
 		testValue = getTestData(testSize, random);
 
 		if (partialWrite(cmdRunner, lba, testSize, testValue) == false)
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 
 		if (partialReadAndCompare(cmdRunner, lba, testSize, testValue) == false)
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 
 		lba += testSize;
 
@@ -35,10 +35,10 @@ void FullWriteAndReadCompareCommand::run(const CommandRunner& cmdRunner) const
 		testValue = getTestData(testSize, random);
 
 		if (partialWrite(cmdRunner, lba, testSize, testValue) == false)
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 
 		if (partialReadAndCompare(cmdRunner, lba, testSize, testValue) == false)
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 
 		lba += testSize;
 	}

--- a/TestShell/main.cpp
+++ b/TestShell/main.cpp
@@ -10,9 +10,7 @@ int main(void) {
 #include "ssd_impl.h"
 
 int main(int argc, char* argv[]) {
-	SsdImpl ssd;
 	TestShell& shell = TestShell::getShell();
-	shell.runner.setStorage(&ssd);
 	shell.runShell(argc, argv);
 }
 

--- a/TestShell/partial_LBA_write_command.cpp
+++ b/TestShell/partial_LBA_write_command.cpp
@@ -35,7 +35,7 @@ void PartialLBAWriteCommand::run(const CommandRunner& cmdRunner) const
 		}
 
 		if (checkResult(result) == false) {
-			throw TestScriptFailExcpetion("Fail");
+			throw CommandRunFailException("Fail");
 		}
 	}
 

--- a/TestShell/shell.cpp
+++ b/TestShell/shell.cpp
@@ -1,13 +1,20 @@
 #include "shell.h"
+#include "ssd_impl.h"
 
 void TestShell::runShell(int argc, char* argv[]) {
-	string input;
 
 	if (isRunShellScript(argc) == true) {
 		string filePath = argv[1];
 		runShellScript(filePath);
 		return;
 	}
+
+	startShellLoop();
+}
+
+void TestShell::startShellLoop()
+{
+	string input;
 
 	while (1) {
 		input = getUserInput();
@@ -69,12 +76,22 @@ bool TestShell::parseAndRunCommand(const string& input) {
 	bool result = true;
 	try {
 		auto command = parser.parseAndMakeShellCommand(input);
-		command->run(runner);
+		runShellCommand(command);
 	}
-	catch (TestScriptFailExcpetion& e) {
+	catch (std::exception& e) {
 		printTestResult(e.what());
 		result = false;
 	}
 
 	return result;
+}
+
+void TestShell::runShellCommand(std::shared_ptr<Command> command)
+{
+	command->run(runner);
+}
+
+TestShell::TestShell() {
+	runner.setStorage(new SsdImpl());
+
 }

--- a/TestShell/shell.h
+++ b/TestShell/shell.h
@@ -13,7 +13,6 @@ using std::ifstream;
 
 class TestShell {
 public:
-	CommandRunner runner;
 
 	static TestShell& getShell() {
 		static TestShell instance;
@@ -23,19 +22,23 @@ public:
 	void runShell(int argc, char* argv[]);
 
 private:
+	void startShellLoop();
+
 	void printTestResult(const string& result);
 	void runShellScript(const string& input);
 
 	bool parseAndRunCommand(const string& input);
+	void runShellCommand(std::shared_ptr<Command> command);
 	bool isRunShellScript(int argc);
 	bool isEmptyInput(const string& input);
 	bool isFileOpenFail(const ifstream& inputFile);
 
 	string getUserInput();
 
-	TestShell() {};
+	TestShell();
 	TestShell& operator=(const TestShell& other) = delete;
 	TestShell(const TestShell& other) = delete;
 
+	CommandRunner runner;
 	CommandParser parser;
 };

--- a/TestShell/test_command_parser.cpp
+++ b/TestShell/test_command_parser.cpp
@@ -20,7 +20,7 @@ TEST(CommandParserTest, ReadWithWrongArgs) {
 	CommandParser cmdParser;
 	string inputCommand = "read 0 0";
 
-	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), TestScriptFailExcpetion);
+	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), std::invalid_argument);
 }
 
 TEST(CommandParserTest, Write) {
@@ -35,7 +35,7 @@ TEST(CommandParserTest, WriteWithWrongArgs) {
 	CommandParser cmdParser;
 	string inputCommand = "write 0 0 0";
 
-	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), TestScriptFailExcpetion);
+	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), std::invalid_argument);
 }
 
 TEST(CommandParserTest, Help) {
@@ -51,7 +51,7 @@ TEST(CommandParserTest, HelpWithWrongArgs) {
 	CommandParser cmdParser;
 	string inputCommand = "help 0";
 
-	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), TestScriptFailExcpetion);
+	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), std::invalid_argument);
 }
 
 TEST(CommandParserTest, Exit) {
@@ -66,12 +66,12 @@ TEST(CommandParserTest, ExitWithWrongArgs) {
 	CommandParser cmdParser;
 	string inputCommand = "exit 0";
 
-	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), TestScriptFailExcpetion);
+	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), std::invalid_argument);
 }
 
 TEST(CommandParserTest, InValidCommand) {
 	CommandParser cmdParser;
 	string inputCommand = "R 0";
-	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), TestScriptFailExcpetion);
+	EXPECT_THROW(cmdParser.parseAndMakeShellCommand(inputCommand), std::invalid_argument);
 }
 #endif

--- a/TestShell/write_read_aging_command.cpp
+++ b/TestShell/write_read_aging_command.cpp
@@ -22,13 +22,13 @@ void WriteReadAgingCommand::run(const CommandRunner& cmdRunner) const
 		string data = rng.generateRandomUnsignedIntString();
 
 		if (WRITESUCCESS != cmdRunner.write(std::to_string(MIN_LBA), data))
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 
 		if (WRITESUCCESS != cmdRunner.write(std::to_string(MAX_LBA), data))
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 
 		if (cmdRunner.read(std::to_string(MIN_LBA)) != cmdRunner.read(std::to_string(MAX_LBA)))
-			throw TestScriptFailExcpetion(FAIL);
+			throw CommandRunFailException(FAIL);
 	}
 
 	std::cout << "Pass" << std::endl;


### PR DESCRIPTION
패치 내용
- Shell 코드 간단한 리팩토링 하였습니다.
패치 세부 내용
1. Command 실행 실패 Exception 과 cmd parsing 실패 Exception 은 분리
2. 처리는 같습니다. 다만 Exception 만 일단 분리하였습니다.
3.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
