### PR TITLE
[Refac] XXXCommand class의 객체는 각 Command의 factory에서만 하도록 수정하였습니다.

### DIFF
--- a/TestShell/erase_command.cpp
+++ b/TestShell/erase_command.cpp
@@ -42,5 +42,5 @@ void EraseCommand::printHelp() const
 std::shared_ptr<Command> EraseCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<EraseCommand>(args);
+	return std::shared_ptr<EraseCommand>(new EraseCommand(args));
 }

--- a/TestShell/erase_command.h
+++ b/TestShell/erase_command.h
@@ -4,14 +4,16 @@
 
 class EraseCommand : public Command {
 public:
-	EraseCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
 	void printResult(const string& result, const string& lba) const;
 private:
+	EraseCommand(const std::vector<std::string>& args);
+
 	string startLBA;
 	string LBARange;
+
+	friend class EraseCommandFactory;
 };
 
 class EraseCommandFactory : public CommandFactory {

--- a/TestShell/erase_range_command.cpp
+++ b/TestShell/erase_range_command.cpp
@@ -52,5 +52,5 @@ void EraseRangeCommand::printHelp() const
 std::shared_ptr<Command> EraseRangeCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<EraseRangeCommand>(args);
+	return std::shared_ptr<EraseRangeCommand>(new EraseRangeCommand(args));
 }

--- a/TestShell/erase_range_command.h
+++ b/TestShell/erase_range_command.h
@@ -4,14 +4,15 @@
 
 class EraseRangeCommand : public Command {
 public:
-	EraseRangeCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
 	void printResult(const string& result, const string& lba) const;
 private:
+	EraseRangeCommand(const std::vector<std::string>& args);
 	string startLBA;
 	string endLBA;
+
+	friend class EraseRangeCommandFactory;
 };
 
 class EraseRangeCommandFactory : public CommandFactory {

--- a/TestShell/exit_command.cpp
+++ b/TestShell/exit_command.cpp
@@ -25,5 +25,5 @@ void ExitCommand::printHelp() const
 std::shared_ptr<Command> ExitCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<ExitCommand>(args);
+	return std::shared_ptr<ExitCommand>(new ExitCommand(args));
 }

--- a/TestShell/exit_command.h
+++ b/TestShell/exit_command.h
@@ -4,11 +4,12 @@
 
 class ExitCommand : public Command {
 public:
-
-	ExitCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
+private:
+	ExitCommand(const std::vector<std::string>& args);
+
+	friend class ExitCommandFactory;
 };
 
 class ExitCommandFactory : public CommandFactory {

--- a/TestShell/full_read_command.cpp
+++ b/TestShell/full_read_command.cpp
@@ -37,5 +37,5 @@ void FullReadCommand::printHelp() const
 std::shared_ptr<Command> FullReadCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<FullReadCommand>(args);
+	return std::shared_ptr<FullReadCommand>(new FullReadCommand(args));
 }

--- a/TestShell/full_read_command.h
+++ b/TestShell/full_read_command.h
@@ -4,12 +4,13 @@
 
 class FullReadCommand : public Command {
 public:
-
-	FullReadCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printResult(const string& result, const string& lba) const;
 	void printHelp() const override;
+private:
+	FullReadCommand(const std::vector<std::string>& args);
+
+	friend class FullReadCommandFactory;
 };
 
 class FullReadCommandFactory : public CommandFactory {

--- a/TestShell/full_write_and_read_compare_command.cpp
+++ b/TestShell/full_write_and_read_compare_command.cpp
@@ -104,5 +104,5 @@ std::shared_ptr<Command> FullWriteAndReadCompareCommandFactory::makeCommand(cons
 																			, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<FullWriteAndReadCompareCommand>(args);
+	return std::shared_ptr<FullWriteAndReadCompareCommand>(new FullWriteAndReadCompareCommand(args));
 }

--- a/TestShell/full_write_and_read_compare_command.h
+++ b/TestShell/full_write_and_read_compare_command.h
@@ -4,13 +4,16 @@
 
 class FullWriteAndReadCompareCommand : public Command {
 public:
-	FullWriteAndReadCompareCommand(const std::vector<std::string>& args);
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
 private:
+	FullWriteAndReadCompareCommand(const std::vector<std::string>& args);
 	bool partialWrite(const CommandRunner& cmdRunner, int lba, int testSize, const vector<string>& data) const;
 	bool partialReadAndCompare(const CommandRunner& cmdRunner, int lba, int testSize, const vector<string>& data) const;
+
 	vector<string> getTestData(int testsize, int random) const;
+
+	friend class FullWriteAndReadCompareCommandFactory;
 };
 
 class FullWriteAndReadCompareCommandFactory : public CommandFactory {

--- a/TestShell/full_write_command.cpp
+++ b/TestShell/full_write_command.cpp
@@ -49,5 +49,5 @@ void FullWriteCommand::printHelp() const
 std::shared_ptr<Command> FullWriteCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<FullWriteCommand>(args);
+	return std::shared_ptr<FullWriteCommand>(new FullWriteCommand(args));
 }

--- a/TestShell/full_write_command.h
+++ b/TestShell/full_write_command.h
@@ -4,14 +4,14 @@
 
 class FullWriteCommand : public Command {
 public:
-
-	FullWriteCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printResult(const string& result) const;
 	void printHelp() const override;
 private:
+	FullWriteCommand(const std::vector<std::string>& args);
 	string value;
+
+	friend class FullWriteCommandFactory;
 };
 
 class FullWriteCommandFactory : public CommandFactory {

--- a/TestShell/help_command.cpp
+++ b/TestShell/help_command.cpp
@@ -40,5 +40,5 @@ void HelpCommand::run(const CommandRunner& cmdRunner) const
 std::shared_ptr<Command> HelpCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<HelpCommand>(args);
+	return std::shared_ptr<HelpCommand>(new HelpCommand(args));
 }

--- a/TestShell/help_command.h
+++ b/TestShell/help_command.h
@@ -4,10 +4,12 @@
 
 class HelpCommand : public Command {
 public:
-	HelpCommand(const std::vector<std::string>& args);
-
 	void printHelp() const override;
 	void run(const CommandRunner& cmdRunner) const override;
+private:
+	HelpCommand(const std::vector<std::string>& args);
+
+	friend class HelpCommandFactory;
 };
 
 class HelpCommandFactory : public CommandFactory {

--- a/TestShell/partial_LBA_write_command.cpp
+++ b/TestShell/partial_LBA_write_command.cpp
@@ -54,5 +54,5 @@ void PartialLBAWriteCommand::printHelp() const
 std::shared_ptr<Command> PartialLBAWriteCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<PartialLBAWriteCommand>(args);
+	return std::shared_ptr<PartialLBAWriteCommand>(new PartialLBAWriteCommand(args));
 }

--- a/TestShell/partial_LBA_write_command.h
+++ b/TestShell/partial_LBA_write_command.h
@@ -4,7 +4,6 @@
 
 class PartialLBAWriteCommand : public Command {
 public:
-	PartialLBAWriteCommand(const std::vector<std::string>& cmd);
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
 private:
@@ -13,6 +12,9 @@ private:
 	std::vector<std::string> TestLbaList = { "4","0","3","1","2" };
 
 	bool checkResult(const std::vector<std::string>& result) const;
+	PartialLBAWriteCommand(const std::vector<std::string>& cmd);
+
+	friend class PartialLBAWriteCommandFactory;
 };
 
 class PartialLBAWriteCommandFactory : public CommandFactory {

--- a/TestShell/read_command.cpp
+++ b/TestShell/read_command.cpp
@@ -38,5 +38,5 @@ void ReadCommand::printHelp() const
 std::shared_ptr<Command> ReadCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<ReadCommand>(args);
+	return std::shared_ptr<ReadCommand>(new ReadCommand(args));
 }

--- a/TestShell/read_command.h
+++ b/TestShell/read_command.h
@@ -4,12 +4,14 @@
 
 class ReadCommand : public Command {
 public:
-	ReadCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
 	void printResult(const string& result, const string& lba) const;
 	string LBA;
+private:
+	ReadCommand(const std::vector<std::string>& args);
+
+	friend class ReadCommandFactory;
 };
 
 class ReadCommandFactory : public CommandFactory {

--- a/TestShell/write_command.cpp
+++ b/TestShell/write_command.cpp
@@ -41,5 +41,5 @@ void WriteCommand::printHelp() const
 std::shared_ptr<Command> WriteCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<WriteCommand>(args);
+	return std::shared_ptr<WriteCommand>(new WriteCommand(args));
 }

--- a/TestShell/write_command.h
+++ b/TestShell/write_command.h
@@ -4,15 +4,16 @@
 
 class WriteCommand : public Command {
 public:
-
-	WriteCommand(const std::vector<std::string>& args);
-
 	void run(const CommandRunner& cmdRunner) const override;
 	void printResult(const string& result) const;
 	void printHelp() const override;
 private:
 	string LBA;
 	string value;
+
+	WriteCommand(const std::vector<std::string>& args);
+
+	friend class WriteCommandFactory;
 };
 
 class WriteCommandFactory : public CommandFactory {

--- a/TestShell/write_read_aging_command.cpp
+++ b/TestShell/write_read_aging_command.cpp
@@ -46,5 +46,5 @@ void WriteReadAgingCommand::printHelp() const
 std::shared_ptr<Command> WriteReadAgingCommandFactory::makeCommand(const string& cmdName, const std::vector<string>& args)
 {
 	if (args.size() != numOfArgs) return nullptr;
-	return std::make_shared<WriteReadAgingCommand>(args);
+	return std::shared_ptr<WriteReadAgingCommand>(new WriteReadAgingCommand(args));
 }

--- a/TestShell/write_read_aging_command.h
+++ b/TestShell/write_read_aging_command.h
@@ -4,10 +4,12 @@
 
 class WriteReadAgingCommand : public Command {
 public:
-	WriteReadAgingCommand(const std::vector<std::string>& args);
 	void run(const CommandRunner& cmdRunner) const override;
 	void printHelp() const override;
 private:
+	WriteReadAgingCommand(const std::vector<std::string>& args);
+
+	friend class WriteReadAgingCommandFactory;
 };
 
 class WriteReadAgingCommandFactory : public CommandFactory {


### PR DESCRIPTION
패치 내용
- 각 Command 객체는 factory를 통해서만 생성할 수 있도록 수정하였습니다.
패치 세부 내용
1. friend class XXXFactory; 를 사용하여서 각 factory에서 생성자 접근 가능하도록 수정
2. Factory::make_command()에서 new XXXCommand 를 통해 객체 생성
3.

이 부분은 중점적으로 봐주세요
- header file에선 모두 `생성자 private으로 옮기기` 수정만 하고 있습니다.
-  cpp file에선 factory 부분에서 `make_shared` 가 아닌 `shared_ptr`를 사용하여 객체 pointer를 반환합니다.

Check lists
- [ ] Ctrl + K + D 로 포매팅 확인
- [ ] Build 확인 (master branch 기준)
- [ ] Unit Test 100% 통과 확인 (master branch 기준)
- [ ] 이상한 파일이 들어가지 않았는지 확인
