### PR TITLE
ssd_nand.txt 파일에 0~9 LBA address에 대해 2자리가 아닌 1자리로 출력하는 버그 수정

### DIFF
--- a/SSD/nand_flash_memory_impl.cpp
+++ b/SSD/nand_flash_memory_impl.cpp
@@ -18,7 +18,7 @@ string NandFlashMemoryImpl::write(const vector<string>& datas) {
 	vector<string> ret;
 	for (int i = 0; i < 100; i++) {
 		std::ostringstream oss;
-		oss << i << '\t' << datas.at(i);
+		oss << std::setw(2) << std::setfill('0') << std::dec << i << '\t' << datas.at(i);
 		ret.push_back(oss.str());
 	}
 	fileHandler->write(NAND_FILENAME, ret);


### PR DESCRIPTION
패치 내용
- ssd_nand.txt 파일에 0~9 LBA address에 대해 2자리가 아닌 1자리로 출력하는 버그 수정
- 버그 내용 : buffer를 다 채우고 write가 실제로 발생 시 LBA Address 0 --> 9까지는 00 --> 09 가 아닌 0 1 2 ... 9로 ssd_nand.txt에 저장되는 문제

패치 세부 내용
1. format 문자 맞춤
2. https://github.com/skycs97/-ERROR_FREE-SSD/issues/78 의 ssd.exe 관련 오류 수정 입니다. 
   testshell에서는 여전히 오류가 발생하고 있습니다.

이 부분은 중점적으로 봐주세요

Check lists
- [X] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [X] Unit Test 100% 통과 확인 (master branch 기준)
- [X] 이상한 파일이 들어가지 않았는지 확인
