### PR TITLE
erase file을 파싱할 때 write regex를 사용하여 발생한 버그 수정

### DIFF
--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -124,9 +124,9 @@ void BufferManager::setEmptyBufferInfo(int buf_idx, const string& fname)
 
 void BufferManager::setEraseBufferInfo(int buf_idx, const string& fname)
 {
-	std::regex writeRegex(R"([1-5]_W_([0-9]*)_(0x[0-9A-Fa-f]+))");
+	std::regex eraseRegex(R"([1-5]_E_([0-9]*)_([0-9]+))");
 	std::smatch m;
-	std::regex_search(fname, m, writeRegex);
+	std::regex_search(fname, m, eraseRegex);
 	setBufferInfo(buf_idx,
 		CMD_ERASE,
 		std::atoi(m.str(1).c_str())/*LBA*/,

--- a/SSD/buffer_manager_test.cpp
+++ b/SSD/buffer_manager_test.cpp
@@ -183,3 +183,43 @@ TEST_F(BufferManagerFixture, TC10) {
 	// E 0 3 이 이후에 들어온 W 명령어들에 의해 지워집니다.
 	EXPECT_EQ(3, manager.getUsedBufferCount());
 }
+
+TEST_F(BufferManagerFixture, FileNameTest1) {
+	manager.init();
+	EXPECT_CALL(fileHandler, rename(_, "buffer\\1_E_0_3"))
+		.Times(1);
+	manager.addEraseCommand(0, 3);
+}
+
+TEST_F(BufferManagerFixture, FileNameTest2) {
+	manager.init();
+	EXPECT_CALL(fileHandler, rename(_, "buffer\\1_W_10_0x11111111"))
+		.Times(1);
+	manager.addWriteCommand(10, "0x11111111");
+}
+
+TEST_F(BufferManagerFixture, InitEraseAndEraseTest) {
+	EXPECT_CALL(fileHandler, isExist(_, _, _))
+		.WillOnce(Return(true))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(fileHandler, findFileUsingPrefix)
+		.WillOnce(Return(vector<string>{"1_E_0_3"}));
+	EXPECT_CALL(fileHandler, rename("buffer\\1_E_0_3", "buffer\\1_E_0_5"))
+		.Times(1);
+	manager.init();
+	
+	manager.addEraseCommand(0, 5);
+}
+
+TEST_F(BufferManagerFixture, InitWriteAndEraseTest) {
+	EXPECT_CALL(fileHandler, isExist(_, _, _))
+		.WillOnce(Return(true))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(fileHandler, findFileUsingPrefix)
+		.WillOnce(Return(vector<string>{"1_W_0_0x11112222"}));
+	EXPECT_CALL(fileHandler, rename("buffer\\1_W_0_0x11112222", "buffer\\1_E_0_5"))
+		.Times(1);
+	manager.init();
+
+	manager.addEraseCommand(0, 5);
+}


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1.  erase file을 파싱할 때 write regex를 사용하여 발생한 버그 수정

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
