### PR TITLE
[fix] maxLBA 값이 erase 영역과 걸친 write 이면 buffer에 기록이 안되는 이슈

### DIFF
--- a/SSD/buffer_info.cpp
+++ b/SSD/buffer_info.cpp
@@ -1,0 +1,51 @@
+#include <regex>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include "buffer_info.h"
+#include "global_config.h"
+
+using std::string;
+using std::vector;
+
+const std::regex WriteBufferInfo::fileNameRegex = std::regex{ R"([1-5]_W_([0-9]*)_(0x[0-9A-Fa-f]+))" };
+const std::regex EraseBufferInfo::fileNameRegex = std::regex{ R"([1-5]_E_([0-9]*)_([0-9]+))" };
+
+void WriteBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+	internalBufferInfos[lba].cmd = CMD_WRITE;
+	internalBufferInfos[lba].data = written_data;
+}
+
+void EraseBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+	for (int count = 0; count < size; count++) {
+		internalBufferInfos[lba + count].cmd = CMD_ERASE;
+		internalBufferInfos[lba + count].data = NAND_DATA_EMPTY;
+	}
+}
+
+void EmptyBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+	// emptyBufferInfo는 InternalBufferInfo 에 아무런 영향을 주지 않습니다.
+}
+
+string WriteBufferInfo::getFileName(int bufIndex) {
+	std::ostringstream oss;
+	oss << bufIndex + 1 << "_W_" << lba << "_" << written_data;
+	string fileName = oss.str();
+	return fileName;
+}
+
+string EraseBufferInfo::getFileName(int bufIndex) {
+	std::ostringstream oss;
+	oss << bufIndex + 1 << "_E_" << lba << "_" << size;
+	string fileName = oss.str();
+	return fileName;
+}
+
+string EmptyBufferInfo::getFileName(int bufIndex) {
+	std::ostringstream oss;
+	oss << bufIndex + 1 << "_empty";
+	string fileName = oss.str();
+	return fileName;
+}
+

--- a/SSD/buffer_info.h
+++ b/SSD/buffer_info.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <regex>
+#include <string>
+#include <vector>
+#include "global_config.h"
+using std::string;
+using std::vector;
+
+struct InternalBufferInfo {
+	CMD_TYPE cmd;
+	string data;
+};
+
+class BufferInfo
+{
+public:
+	virtual string getFileName(int bufIndex) = 0;
+	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>) = 0;
+};
+
+class WriteBufferInfo : public BufferInfo {
+public:
+	static const std::regex fileNameRegex;
+	WriteBufferInfo(int lba, const string& data) :lba{ lba }, written_data(data) {}
+	WriteBufferInfo(const string& fname) {
+		std::smatch m;
+		std::regex_search(fname, m, WriteBufferInfo::fileNameRegex);
+		lba = std::atoi(m.str(1).c_str());
+		written_data = m.str(2);
+	}
+	string getFileName(int bufIndex) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	string written_data;
+	int lba;
+};
+
+class EraseBufferInfo : public BufferInfo {
+public:
+	static const std::regex fileNameRegex;
+	EraseBufferInfo(int lba, int size) : lba{ lba }, size(size) {}
+	EraseBufferInfo(const string& fname) {
+		std::smatch m;
+		std::regex_search(fname, m, EraseBufferInfo::fileNameRegex);
+		lba = std::atoi(m.str(1).c_str())/*LBA*/;
+		size = std::atoi(m.str(2).c_str())/*erase size*/;
+	}
+	string getFileName(int bufIndex) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	int size;
+	int lba;
+};
+
+class EmptyBufferInfo : public BufferInfo {
+public:
+	EmptyBufferInfo() {}
+	string getFileName(int bufIndex) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+};
+

--- a/SSD/buffer_info_factory.cpp
+++ b/SSD/buffer_info_factory.cpp
@@ -1,0 +1,12 @@
+#include "buffer_info_factory.h"
+#include <regex>
+
+BufferInfo* BufferInfoFactory::createCommand(const string& fname) {
+	if (std::regex_match(fname, WriteBufferInfo::fileNameRegex)) {
+		return new WriteBufferInfo(fname);
+	}
+	else if (std::regex_match(fname, EraseBufferInfo::fileNameRegex)) {
+		return new EraseBufferInfo(fname);
+	}
+	return new EmptyBufferInfo();
+}

--- a/SSD/buffer_info_factory.h
+++ b/SSD/buffer_info_factory.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "buffer_info.h"
+#include "global_config.h"
+
+class BufferInfoFactory {
+public:
+	BufferInfo* createCommand(const string& fileName);
+
+	static BufferInfoFactory& getInstance() {
+		static BufferInfoFactory instance;
+		return instance;
+	}
+private:
+	BufferInfoFactory() = default;
+	BufferInfoFactory& operator=(const BufferInfoFactory& other) = delete;
+	BufferInfoFactory(const BufferInfoFactory& other) = delete;
+};

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -204,7 +204,7 @@ void BufferManager::updateBuffer() {
 				meetErase = false;
 			}
 
-			else if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
+			if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
 				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
 				int erase_count = internalBufferIdx - eraseStartLBA + 1;
 				fillEraseBufferInfo(buf_idx, eraseStartLBA, erase_count);

--- a/SSD/buffer_manager_test.cpp
+++ b/SSD/buffer_manager_test.cpp
@@ -219,3 +219,10 @@ TEST_F(BufferManagerFixture, InitWriteAndEraseTest) {
 
 	manager.addEraseCommand(0, 5);
 }
+
+TEST_F(BufferManagerFixture, MAXLBA_TEST) {
+	manager.addEraseCommand(97, 3);
+	manager.addWriteCommand(99, "0x11111111");
+
+	EXPECT_EQ(2, manager.getUsedBufferCount());
+}


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1. erase 영역과 인접한 write 가 erase 기준으로 count = 10 이거나 maxlba 인 경우 buffer에 적히지 않는 버그를 수정합니다.
2. 
3.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
