### PR TITLE
[fix] maxLBA 값이 erase 영역과 걸친 write 이면 buffer에 기록이 안되는 이슈

### DIFF
--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -204,7 +204,7 @@ void BufferManager::updateBuffer() {
 				meetErase = false;
 			}
 
-			else if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
+			if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
 				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
 				int erase_count = internalBufferIdx - eraseStartLBA + 1;
 				fillEraseBufferInfo(buf_idx, eraseStartLBA, erase_count);

--- a/SSD/buffer_manager_test.cpp
+++ b/SSD/buffer_manager_test.cpp
@@ -219,3 +219,11 @@ TEST_F(BufferManagerFixture, InitWriteAndEraseTest) {
 
 	manager.addEraseCommand(0, 5);
 }
+
+
+TEST_F(BufferManagerFixture, MAXLBA_TEST) {
+	manager.addEraseCommand(97, 3);
+	manager.addWriteCommand(99, "0x11111111");
+
+	EXPECT_EQ(2, manager.getUsedBufferCount());
+}


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1. erase 와 인접한 write 가 erase 기준으로 count = 10 이거나 maxLBA 일때 erase buffer와 write buffer 를 파일로 입력하지 않는 버그를 수정합니다.
2.
3.
![image](https://github.com/user-attachments/assets/a2dd6eb4-8b65-4153-a631-61f8fea4b47c)

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
