### PR TITLE
[fix] debug build err fix

### DIFF
--- a/TestShell/helper.cpp
+++ b/TestShell/helper.cpp
@@ -4,7 +4,7 @@
 
 std::map<std::string, std::string> Helper::cmdHelpList{};
 
-std::string Helper::printAllHelp() {
+void Helper::printAllHelp() {
 	for (auto cmdName : AVAILABLE_COMMAND_LIST) {
 		printCmdHelp(cmdName);
 	}

--- a/TestShell/helper.h
+++ b/TestShell/helper.h
@@ -4,7 +4,7 @@
 
 class Helper {
 public:
-	static std::string printAllHelp();
+	static void printAllHelp();
 	static std::string getCmdHelp(const std::string& cmdName);
 	static void printCmdHelp(const std::string& cmdName);
 	static void registerCmd(const std::string& cmdName, const std::string& helpStr);


### PR DESCRIPTION
패치 내용
- build error 수정
패치 세부 내용
1. printAllHelp 의 return이 string 인데 아무것도 리턴하지 않아서 문제가 되었습니다.
2. Debug 에서는 함수 return을 더 엄격하게 관리하는것으로 보입니다 
3.
4.

이 부분은 중점적으로 봐주세요
- 정말 죄송합니다.

Check lists
- [ ] Ctrl + K + D 로 포매팅 확인
- [ ] Build 확인 (master branch 기준)
- [ ] Unit Test 100% 통과 확인 (master branch 기준)
- [ ] 이상한 파일이 들어가지 않았는지 확인
