### PR TITLE
Ssd/refactor buffer info

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -129,6 +129,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="buffer_info.cpp" />
     <ClCompile Include="buffer_manager.cpp" />
     <ClCompile Include="buffer_manager_test.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'"> %(AdditionalOptions)</AdditionalOptions>
@@ -166,7 +167,6 @@
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Release|x64'"> %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <ClCompile Include="ssd_command.cpp" />
-    <ClCompile Include="ssd_command_test.cpp" />
     <ClCompile Include="write_command.cpp" />
     <ClCompile Include="write_command_test.cpp" />
     <ClCompile Include="ssd.cpp" />
@@ -198,6 +198,7 @@
     <ClInclude Include="flush_command.h" />
     <ClInclude Include="output_handler.h" />
     <ClInclude Include="ssd.h" />
+    <ClInclude Include="buffer_info.h" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="nand_flash_memory.h" />

--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -130,6 +130,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="buffer_info.cpp" />
+    <ClCompile Include="buffer_info_factory.cpp" />
     <ClCompile Include="buffer_manager.cpp" />
     <ClCompile Include="buffer_manager_test.cpp">
       <AdditionalOptions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'"> %(AdditionalOptions)</AdditionalOptions>
@@ -189,6 +190,7 @@
     <ClCompile Include="main.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="buffer_info_factory.h" />
     <ClInclude Include="buffer_manager.h" />
     <ClInclude Include="file_handler.h" />
     <ClInclude Include="file_handler_impl.h" />

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -81,7 +81,9 @@
     <ClCompile Include="buffer_info.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
-    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
+    <ClCompile Include="buffer_info_factory.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
@@ -137,6 +139,9 @@
     <ClInclude Include="buffer_info.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>    <ClInclude Include="file_handler_impl.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="buffer_info_factory.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -21,6 +21,12 @@
     <ClCompile Include="main.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gmock\gmock-all.cc">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
     <ClCompile Include="read_command_test.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
@@ -72,7 +78,7 @@
     <ClCompile Include="file_handler_impl_test.cpp">
       <Filter>테스트 파일</Filter>
     </ClCompile>
-    <ClCompile Include="ssd_command_test.cpp">
+    <ClCompile Include="buffer_info.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\gtest\gtest-all.cc">
@@ -128,7 +134,9 @@
     <ClInclude Include="ssd_command.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
-    <ClInclude Include="file_handler_impl.h">
+    <ClInclude Include="buffer_info.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>    <ClInclude Include="file_handler_impl.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
   </ItemGroup>

--- a/SSD/buffer_info.cpp
+++ b/SSD/buffer_info.cpp
@@ -12,19 +12,19 @@ using std::vector;
 const std::regex WriteBufferInfo::fileNameRegex = std::regex{ R"([1-5]_W_([0-9]*)_(0x[0-9A-Fa-f]+))" };
 const std::regex EraseBufferInfo::fileNameRegex = std::regex{ R"([1-5]_E_([0-9]*)_([0-9]+))" };
 
-void WriteBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+void WriteBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo>& internalBufferInfos) {
 	internalBufferInfos[lba].cmd = CMD_WRITE;
 	internalBufferInfos[lba].data = written_data;
 }
 
-void EraseBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+void EraseBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo>& internalBufferInfos) {
 	for (int count = 0; count < size; count++) {
 		internalBufferInfos[lba + count].cmd = CMD_ERASE;
 		internalBufferInfos[lba + count].data = NAND_DATA_EMPTY;
 	}
 }
 
-void EmptyBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+void EmptyBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo>& internalBufferInfos) {
 	// emptyBufferInfo는 InternalBufferInfo 에 아무런 영향을 주지 않습니다.
 }
 

--- a/SSD/buffer_info.cpp
+++ b/SSD/buffer_info.cpp
@@ -1,0 +1,51 @@
+#include <regex>
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iomanip>
+#include "buffer_info.h"
+#include "global_config.h"
+
+using std::string;
+using std::vector;
+
+const std::regex WriteBufferInfo::fileNameRegex = std::regex{ R"([1-5]_W_([0-9]*)_(0x[0-9A-Fa-f]+))" };
+const std::regex EraseBufferInfo::fileNameRegex = std::regex{ R"([1-5]_E_([0-9]*)_([0-9]+))" };
+
+void WriteBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+	internalBufferInfos[lba].cmd = CMD_WRITE;
+	internalBufferInfos[lba].data = written_data;
+}
+
+void EraseBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+	for (int count = 0; count < size; count++) {
+		internalBufferInfos[lba + count].cmd = CMD_ERASE;
+		internalBufferInfos[lba + count].data = NAND_DATA_EMPTY;
+	}
+}
+
+void EmptyBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
+	// emptyBufferInfo는 InternalBufferInfo 에 아무런 영향을 주지 않습니다.
+}
+
+string WriteBufferInfo::getFileName(int bufIndex) {
+	std::ostringstream oss;
+	oss << bufIndex + 1 << "_W_" << lba << "_" << written_data;
+	string fileName = oss.str();
+	return fileName;
+}
+
+string EraseBufferInfo::getFileName(int bufIndex) {
+	std::ostringstream oss;
+	oss << bufIndex + 1 << "_E_" << lba << "_" << size;
+	string fileName = oss.str();
+	return fileName;
+}
+
+string EmptyBufferInfo::getFileName(int bufIndex) {
+	std::ostringstream oss;
+	oss << bufIndex + 1 << "_empty";
+	string fileName = oss.str();
+	return fileName;
+}
+

--- a/SSD/buffer_info.h
+++ b/SSD/buffer_info.h
@@ -1,0 +1,59 @@
+#pragma once
+#include <regex>
+#include <string>
+#include <vector>
+#include "global_config.h"
+using std::string;
+using std::vector;
+
+struct InternalBufferInfo {
+	CMD_TYPE cmd;
+	string data;
+};
+
+class BufferInfo
+{
+public:
+	virtual string getFileName(int bufIndex) = 0;
+	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>) = 0;
+};
+
+class WriteBufferInfo : public BufferInfo {
+public:
+	static const std::regex fileNameRegex;
+	WriteBufferInfo(int lba, const string& data) :lba{ lba }, written_data(data) {}
+	WriteBufferInfo(const string& fname) {
+		std::smatch m;
+		std::regex_search(fname, m, WriteBufferInfo::fileNameRegex);
+		lba = std::atoi(m.str(1).c_str());
+		written_data = m.str(2);
+	}
+	string getFileName(int bufIndex) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	string written_data;
+	int lba;
+};
+
+class EraseBufferInfo : public BufferInfo {
+public:
+	static const std::regex fileNameRegex;
+	EraseBufferInfo(int lba, int size) : lba{ lba }, size(size) {}
+	EraseBufferInfo(const string& fname) {
+		std::smatch m;
+		std::regex_search(fname, m, EraseBufferInfo::fileNameRegex);
+		lba = std::atoi(m.str(1).c_str())/*LBA*/;
+		size = std::atoi(m.str(2).c_str())/*erase size*/;
+	}
+	string getFileName(int bufIndex) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	int size;
+	int lba;
+};
+
+class EmptyBufferInfo : public BufferInfo {
+public:
+	EmptyBufferInfo() {}
+	string getFileName(int bufIndex) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+};
+

--- a/SSD/buffer_info.h
+++ b/SSD/buffer_info.h
@@ -15,7 +15,7 @@ class BufferInfo
 {
 public:
 	virtual string getFileName(int bufIndex) = 0;
-	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>) = 0;
+	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>&) = 0;
 };
 
 class WriteBufferInfo : public BufferInfo {
@@ -29,7 +29,8 @@ public:
 		written_data = m.str(2);
 	}
 	string getFileName(int bufIndex) override;
-	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>&) override;
+private:
 	string written_data;
 	int lba;
 };
@@ -45,7 +46,8 @@ public:
 		size = std::atoi(m.str(2).c_str())/*erase size*/;
 	}
 	string getFileName(int bufIndex) override;
-	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>&) override;
+private:
 	int size;
 	int lba;
 };
@@ -54,6 +56,6 @@ class EmptyBufferInfo : public BufferInfo {
 public:
 	EmptyBufferInfo() {}
 	string getFileName(int bufIndex) override;
-	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>&) override;
 };
 

--- a/SSD/buffer_info_factory.cpp
+++ b/SSD/buffer_info_factory.cpp
@@ -10,3 +10,10 @@ BufferInfo* BufferInfoFactory::createCommand(const string& fname) {
 	}
 	return new EmptyBufferInfo();
 }
+
+BufferInfo* BufferInfoFactory::createWriteCommand(int LBA, const string& data) {
+	return new WriteBufferInfo(LBA, data);
+}
+BufferInfo* BufferInfoFactory::createEraseCommand(int LBA, int size) {
+	return new EraseBufferInfo(LBA, size);
+}

--- a/SSD/buffer_info_factory.cpp
+++ b/SSD/buffer_info_factory.cpp
@@ -1,0 +1,12 @@
+#include "buffer_info_factory.h"
+#include <regex>
+
+BufferInfo* BufferInfoFactory::createCommand(const string& fname) {
+	if (std::regex_match(fname, WriteBufferInfo::fileNameRegex)) {
+		return new WriteBufferInfo(fname);
+	}
+	else if (std::regex_match(fname, EraseBufferInfo::fileNameRegex)) {
+		return new EraseBufferInfo(fname);
+	}
+	return new EmptyBufferInfo();
+}

--- a/SSD/buffer_info_factory.h
+++ b/SSD/buffer_info_factory.h
@@ -6,6 +6,9 @@ class BufferInfoFactory {
 public:
 	BufferInfo* createCommand(const string& fileName);
 
+	BufferInfo* createWriteCommand(int LBA, const string& data);
+	BufferInfo* createEraseCommand(int LBA, int size);
+
 	static BufferInfoFactory& getInstance() {
 		static BufferInfoFactory instance;
 		return instance;

--- a/SSD/buffer_info_factory.h
+++ b/SSD/buffer_info_factory.h
@@ -1,0 +1,17 @@
+#pragma once
+#include "buffer_info.h"
+#include "global_config.h"
+
+class BufferInfoFactory {
+public:
+	BufferInfo* createCommand(const string& fileName);
+
+	static BufferInfoFactory& getInstance() {
+		static BufferInfoFactory instance;
+		return instance;
+	}
+private:
+	BufferInfoFactory() = default;
+	BufferInfoFactory& operator=(const BufferInfoFactory& other) = delete;
+	BufferInfoFactory(const BufferInfoFactory& other) = delete;
+};

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -1,5 +1,6 @@
 ﻿#include "buffer_manager.h"
 #include "buffer_info.h"
+#include "buffer_info_factory.h"
 #include <regex>
 #include <string>
 #include <sstream>
@@ -37,7 +38,7 @@ void BufferManager::createEmptyBufferFile(int bufIndex)
 
 void BufferManager::updateBufferState(int bufIndex)
 {
-	vector<string> buffer_fname = fileHandler->findFileUsingPrefix(BUFFER_DIR_NAME, getBufferFilePrefix(bufIndex));
+	vector<string> buffer_fname = fileHandler->getFileUsingPrefix(BUFFER_DIR_NAME, getBufferFilePrefix(bufIndex));
 
 	if (buffer_fname.size() > 1) throw std::exception("There are many buffer files in same prefix.");
 
@@ -63,19 +64,7 @@ void BufferManager::fillBufferInfo(string fname, int bufIndex)
 {
 	if (bufIndex < 0 || bufIndex >= BUFFER_SIZE) throw std::exception("invalid buffer index.");
 
-	CMD_TYPE bufferType = getBufferTypeFromFilenames(fname);
-	if (bufferType == CMD_WRITE) {
-		buffers[bufIndex] = new WriteBufferInfo(fname);
-		return;
-	}
-	if (bufferType == CMD_ERASE) {
-		buffers[bufIndex] = new EraseBufferInfo(fname);
-		return;
-	}
-	if (bufferType == BUFFER_EMPTY) {
-		buffers[bufIndex] = new EmptyBufferInfo();
-		return;
-	}
+	buffers[bufIndex] = BufferInfoFactory::getInstance().createCommand(fname);
 }
 
 CMD_TYPE BufferManager::getBufferTypeFromFilenames(const string& fname) {

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -51,7 +51,7 @@ void BufferManager::init() {
 	for (int buf_idx = 0; buf_idx < BUFFER_SIZE; buf_idx++)
 	{
 		if (existBufferFile(buf_idx)) updateBufferState(buf_idx);
-		else createBufferFile(buf_idx);
+		else createEmptyBufferFile(buf_idx);
 	}
 }
 
@@ -66,7 +66,7 @@ bool BufferManager::existBufferFile(int buf_idx)
 	return false;
 }
 
-void BufferManager::createBufferFile(int buf_idx)
+void BufferManager::createEmptyBufferFile(int buf_idx)
 {
 	string file_name = getBufferFilePrefix(buf_idx) + BUFFER_NAME_EMPTY;
 	string file_path = BUFFER_DIR_NAME "\\";
@@ -234,7 +234,7 @@ void BufferManager::addEraseCommand(int lba, int count) {
 void BufferManager::flush() {
 	vector<string> datas = nandFlashMemory->read();
 	updateNandData(datas);
-	initInternalBuffers();
+	flushInternalBuffers();
 
 	vector<string> old_names = getOldFileNames();
 	valid_buf_cnt = 0;
@@ -268,7 +268,7 @@ void BufferManager::updateNandData(std::vector<std::string>& outData)
 	}
 }
 
-void BufferManager::initInternalBuffers()
+void BufferManager::flushInternalBuffers()
 {
 	for (int index = 0; index <= MAX_LBA; index++) {
 		internalBuffers[index].cmd = INVALID_VALUE;

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -1,49 +1,9 @@
 ﻿#include "buffer_manager.h"
+#include "buffer_info.h"
 #include <regex>
 #include <string>
 #include <sstream>
 #include <iomanip>
-
-const std::regex WriteBufferInfo::fileNameRegex = std::regex{ R"([1-5]_W_([0-9]*)_(0x[0-9A-Fa-f]+))" };
-const std::regex EraseBufferInfo::fileNameRegex = std::regex{ R"([1-5]_E_([0-9]*)_([0-9]+))" };
-
-void WriteBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
-	internalBufferInfos[lba].cmd = CMD_WRITE;
-	internalBufferInfos[lba].data = written_data;
-}
-
-void EraseBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
-	for (int count = 0; count < size; count++) {
-		internalBufferInfos[lba+count].cmd = CMD_ERASE;
-		internalBufferInfos[lba+count].data = NAND_DATA_EMPTY;
-	}
-}
-
-void EmptyBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
-	// emptyBufferInfo는 InternalBufferInfo 에 아무런 영향을 주지 않습니다.
-}
-
-string WriteBufferInfo::getFileName(int bufIndex) {
-	std::ostringstream oss;
-	oss << bufIndex + 1 << "_W_" << lba << "_" << written_data;
-	string fileName = oss.str();
-	return fileName;
-}
-
-string EraseBufferInfo::getFileName(int bufIndex) {
-	std::ostringstream oss;
-	oss << bufIndex + 1 << "_E_" << lba << "_" << size;
-	string fileName = oss.str();
-	return fileName;
-}
-
-string EmptyBufferInfo::getFileName(int bufIndex) {
-	std::ostringstream oss;
-	oss << bufIndex + 1 << "_empty";
-	string fileName = oss.str();
-	return fileName;
-}
-
 
 void BufferManager::init() {
 	fileHandler->createDirectory(BUFFER_DIR_NAME);

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -23,23 +23,23 @@ void EmptyBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> inter
 	// emptyBufferInfo는 InternalBufferInfo 에 아무런 영향을 주지 않습니다.
 }
 
-string WriteBufferInfo::getFileName(int buf_idx) {
+string WriteBufferInfo::getFileName(int bufIndex) {
 	std::ostringstream oss;
-	oss << buf_idx + 1 << "_W_" << lba << "_" << written_data;
+	oss << bufIndex + 1 << "_W_" << lba << "_" << written_data;
 	string fileName = oss.str();
 	return fileName;
 }
 
-string EraseBufferInfo::getFileName(int buf_idx) {
+string EraseBufferInfo::getFileName(int bufIndex) {
 	std::ostringstream oss;
-	oss << buf_idx + 1 << "_E_" << lba << "_" << size;
+	oss << bufIndex + 1 << "_E_" << lba << "_" << size;
 	string fileName = oss.str();
 	return fileName;
 }
 
-string EmptyBufferInfo::getFileName(int buf_idx) {
+string EmptyBufferInfo::getFileName(int bufIndex) {
 	std::ostringstream oss;
-	oss << buf_idx + 1 << "_empty";
+	oss << bufIndex + 1 << "_empty";
 	string fileName = oss.str();
 	return fileName;
 }
@@ -48,54 +48,73 @@ string EmptyBufferInfo::getFileName(int buf_idx) {
 void BufferManager::init() {
 	fileHandler->createDirectory(BUFFER_DIR_NAME);
 	
-	for (int buf_idx = 0; buf_idx < BUFFER_SIZE; buf_idx++)
+	for (int bufIndex = 0; bufIndex < BUFFER_SIZE; bufIndex++)
 	{
-		if (existBufferFile(buf_idx)) updateBufferState(buf_idx);
-		else createEmptyBufferFile(buf_idx);
+		if (existBufferFile(bufIndex)) updateBufferState(bufIndex);
+		else createEmptyBufferFile(bufIndex);
 	}
 }
 
-bool BufferManager::existBufferFile(int buf_idx)
+bool BufferManager::existBufferFile(int bufIndex)
 {
 	string dir_path = BUFFER_DIR_NAME "\\*";
-	string empty_file_name = getBufferFilePrefix(buf_idx) + BUFFER_NAME_EMPTY;
+	string empty_file_name = getBufferFilePrefix(bufIndex) + BUFFER_NAME_EMPTY;
 	if (fileHandler->isFileExistByMatchLength(dir_path, empty_file_name, empty_file_name.length())) return false;
 
-	string prefix_name = getBufferFilePrefix(buf_idx);
+	string prefix_name = getBufferFilePrefix(bufIndex);
 	if (fileHandler->isFileExistByMatchLength(dir_path, prefix_name, prefix_name.length())) return true;
 	return false;
 }
 
-void BufferManager::createEmptyBufferFile(int buf_idx)
+void BufferManager::createEmptyBufferFile(int bufIndex)
 {
-	string file_name = getBufferFilePrefix(buf_idx) + BUFFER_NAME_EMPTY;
+	string file_name = getBufferFilePrefix(bufIndex) + BUFFER_NAME_EMPTY;
 	string file_path = BUFFER_DIR_NAME "\\";
 	file_path += file_name;
 	fileHandler->createFile(file_path);
-	fillBufferInfo(file_name, buf_idx);
+	fillBufferInfo(file_name, bufIndex);
 }
 
-string BufferManager::getBufferFilePrefix(int buf_idx)
+void BufferManager::updateBufferState(int bufIndex)
 {
-	return std::to_string(buf_idx+1) + "_";
-}
-
-void BufferManager::updateBufferState(int buf_idx)
-{
-	vector<string> buffer_fname = fileHandler->getFileUsingPrefix(BUFFER_DIR_NAME, getBufferFilePrefix(buf_idx));
+	vector<string> buffer_fname = fileHandler->findFileUsingPrefix(BUFFER_DIR_NAME, getBufferFilePrefix(bufIndex));
 
 	if (buffer_fname.size() > 1) throw std::exception("There are many buffer files in same prefix.");
 
-	fillBufferInfo(buffer_fname.front(), buf_idx);
+	fillBufferInfo(buffer_fname.front(), bufIndex);
 	IncreaseBufferCnt();
 
 	updateInternalBufferState();
 }
 
+string BufferManager::getBufferFilePrefix(int bufIndex)
+{
+	return std::to_string(bufIndex+1) + "_";
+}
+
 void BufferManager::updateInternalBufferState()
 {
-	for (int buf_idx = 0; buf_idx < BUFFER_SIZE; buf_idx++) {
-		buffers[buf_idx]->updateInternalBufferInfos(internalBuffers);
+	for (int bufIndex = 0; bufIndex < BUFFER_SIZE; bufIndex++) {
+		buffers[bufIndex]->updateInternalBufferInfos(internalBuffers);
+	}
+}
+
+void BufferManager::fillBufferInfo(string fname, int bufIndex)
+{
+	if (bufIndex < 0 || bufIndex >= BUFFER_SIZE) throw std::exception("invalid buffer index.");
+
+	CMD_TYPE bufferType = getBufferTypeFromFilenames(fname);
+	if (bufferType == CMD_WRITE) {
+		buffers[bufIndex] = new WriteBufferInfo(fname);
+		return;
+	}
+	if (bufferType == CMD_ERASE) {
+		buffers[bufIndex] = new EraseBufferInfo(fname);
+		return;
+	}
+	if (bufferType == BUFFER_EMPTY) {
+		buffers[bufIndex] = new EmptyBufferInfo();
+		return;
 	}
 }
 
@@ -106,26 +125,7 @@ CMD_TYPE BufferManager::getBufferTypeFromFilenames(const string& fname) {
 	else if (std::regex_match(fname, EraseBufferInfo::fileNameRegex)) {
 		return CMD_ERASE;
 	}
-	return INVALID_VALUE;
-}
-
-void BufferManager::fillBufferInfo(string fname, int buf_idx)
-{
-	if (buf_idx < 0 || buf_idx >= BUFFER_SIZE) throw std::exception("invalid buffer index.");
-
-	CMD_TYPE bufferType = getBufferTypeFromFilenames(fname);
-	if (bufferType == CMD_WRITE) {
-		buffers[buf_idx] = new WriteBufferInfo(fname);
-		return;
-	}
-	if (bufferType == CMD_ERASE) {
-		buffers[buf_idx] = new EraseBufferInfo(fname);
-		return;
-	}
-	if (bufferType == INVALID_VALUE) {
-		buffers[buf_idx] = new EmptyBufferInfo();
-		return;
-	}
+	return BUFFER_EMPTY;
 }
 
 bool BufferManager::isBufferFull() {
@@ -133,80 +133,9 @@ bool BufferManager::isBufferFull() {
 }
 
 bool BufferManager::read(int lba, string& outputData) {
-	if (internalBuffers[lba].cmd == INVALID_VALUE) return false;
+	if (internalBuffers[lba].cmd == BUFFER_EMPTY) return false;
 	outputData = internalBuffers[lba].data;
 	return true;
-}
-
-void BufferManager::updateBuffer() {
-	int eraseStartLBA = -1;
-	bool meetErase = false;
-	vector<int> write_lbas;
-	vector<string> old_names = getOldFileNames();
-	int buf_idx = MIN_LBA;
-	for (int internalBufferIdx = MIN_LBA; internalBufferIdx <= MAX_LBA; internalBufferIdx++) {
-		InternalBufferInfo& internalBuffer = internalBuffers[internalBufferIdx];
-		if (meetErase == false) {
-			if (internalBuffer.cmd == CMD_ERASE) {
-				meetErase = true;
-				eraseStartLBA = internalBufferIdx;
-				write_lbas.clear();
-
-				if(isLastLBA(internalBufferIdx))
-					fillEraseBufferInfo(buf_idx, eraseStartLBA, 1);
-			}
-			else if (internalBuffer.cmd == CMD_WRITE) {
-				string data = internalBuffer.data;
-				buffers[buf_idx] = new WriteBufferInfo(internalBufferIdx, data);
-				buf_idx++;
-			}
-		}
-		else {
-			if (internalBuffer.cmd == CMD_WRITE) {
-				// erase 사이에 등장한 write는 따로 기록해 둡니다.
-				write_lbas.push_back(internalBufferIdx);
-			}
-
-			if (internalBuffer.cmd == INVALID_VALUE) {
-				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
-				int erase_count = internalBufferIdx - eraseStartLBA;
-				buffers[buf_idx] = new EraseBufferInfo(eraseStartLBA, erase_count);
-				buf_idx++;
-				for (int write_lba : write_lbas) {
-					string data = internalBuffers[write_lba].data;
-					buffers[buf_idx] = new WriteBufferInfo(write_lba, data);
-					buf_idx++;
-				}
-				meetErase = false;
-			}
-			
-			if (meetErase == true && (internalBufferIdx == MAX_LBA || internalBufferIdx - eraseStartLBA == 9)) {
-				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
-				int erase_count = internalBufferIdx - eraseStartLBA + 1;
-				buffers[buf_idx] = new EraseBufferInfo(eraseStartLBA, erase_count);
-				buf_idx++;
-				for (int write_lba : write_lbas) {
-					string data = internalBuffers[write_lba].data;
-					buffers[buf_idx] = new WriteBufferInfo(write_lba, data);
-					buf_idx++;
-				}
-				meetErase = false;
-			}
-		}
-	}
-	
-	valid_buf_cnt = buf_idx;
-	fillEmptyBuffers();
-	writeAllBufferFiles(old_names);
-}
-
-vector<string> BufferManager::getOldFileNames()
-{
-	vector<string> old_names;
-	for (int i = 0; i < BUFFER_SIZE; i++) {
-		old_names.push_back(buffers[i]->getFileName(i));
-	}
-	return old_names;
 }
 
 void BufferManager::addWriteCommand(int lba, const string& data) {
@@ -217,53 +146,143 @@ void BufferManager::addWriteCommand(int lba, const string& data) {
 	if (isBufferFull()) {
 		flush();
 	}
-	internalBuffers[lba] = { CMD_WRITE, data };
-	updateBuffer();
+	setInternalBufferWrite(lba, data);
+	WriteUpdatedBufferFiles();
 }
+
 
 void BufferManager::addEraseCommand(int lba, int count) {
 	if (isBufferFull()) {
 		flush();
 	}
-	for (int i = lba; i < lba + count; i++) {
-		internalBuffers[i] = { CMD_ERASE, NAND_DATA_EMPTY };
-	}
-	updateBuffer();
+	SetInternalBufferErase(lba, count);
+	WriteUpdatedBufferFiles();
 }
 
 void BufferManager::flush() {
 	vector<string> datas = nandFlashMemory->read();
 	updateNandData(datas);
 	flushInternalBuffers();
-
-	vector<string> old_names = getOldFileNames();
-	valid_buf_cnt = 0;
-	fillEmptyBuffers();
-	writeAllBufferFiles(old_names);
+	writeEmptyBufferFiles();
 
 	nandFlashMemory->write(datas);
 }
 
-void BufferManager::fillEmptyBuffers()
+void BufferManager::setInternalBufferWrite(int lba, const std::string& data)
 {
-	for (int buf_idx = getUsedBufferCount(); buf_idx < BUFFER_SIZE; buf_idx++) {
-		buffers[buf_idx] = new EmptyBufferInfo();
+	internalBuffers[lba] = { CMD_WRITE, data };
+}
+
+void BufferManager::SetInternalBufferErase(int lba, int count)
+{
+	for (int i = lba; i < lba + count; i++) {
+		internalBuffers[i] = { CMD_ERASE, NAND_DATA_EMPTY };
 	}
 }
 
-void BufferManager::writeAllBufferFiles(std::vector<std::string>& old_names)
+void BufferManager::WriteUpdatedBufferFiles()
+{
+	vector<string> oldNames = getOldFileNames();
+	updateBufferByInternalBuffer();
+	writeAllBufferFiles(oldNames);
+}
+
+void BufferManager::writeEmptyBufferFiles()
+{
+	vector<string> oldNames = getOldFileNames();
+	valid_buf_cnt = 0;
+	fillEmptyBuffers();
+	writeAllBufferFiles(oldNames);
+}
+
+void BufferManager::updateBufferByInternalBuffer() {
+	int eraseStartLBA = -1;
+	bool meetErase = false;
+	vector<int> writeLBAs;
+	vector<string> old_names = getOldFileNames();
+	int buf_idx = MIN_LBA;
+	for (int internalBufferIdx = MIN_LBA; internalBufferIdx <= MAX_LBA; internalBufferIdx++) {
+		InternalBufferInfo& internalBuffer = internalBuffers[internalBufferIdx];
+		if (meetErase == false) {
+			if (internalBuffer.cmd == CMD_ERASE) {
+				meetErase = true;
+				eraseStartLBA = internalBufferIdx;
+				writeLBAs.clear();
+
+				if(isLastLBA(internalBufferIdx))
+					fillEraseBufferInfo(buf_idx, eraseStartLBA, 1);
+			}
+			else if (internalBuffer.cmd == CMD_WRITE) {
+				bufIndex = createWriteBuffer(internalBuffer.data, bufIndex, internalBufferIdx);
+			}
+		}
+		else {
+			if (internalBuffer.cmd == CMD_WRITE) {
+				writeLBAs.push_back(internalBufferIdx);
+			}
+
+			if (meetErase == true && (internalBufferIdx == MAX_LBA || internalBufferIdx - eraseStartLBA + 1 == MAX_ERASE_COUNT)) {
+				int eraseCount = internalBufferIdx - eraseStartLBA + 1;
+				bufIndex = createEraseBufferAndPassedWriteBuffer(eraseStartLBA, eraseCount, bufIndex, writeLBAs);
+				meetErase = false;
+			}
+			if (internalBuffer.cmd == BUFFER_EMPTY) {
+				int eraseCount = internalBufferIdx - eraseStartLBA;
+				bufIndex = createEraseBufferAndPassedWriteBuffer(eraseStartLBA, eraseCount, bufIndex, writeLBAs);
+				meetErase = false;
+			}
+		}
+	}
+	valid_buf_cnt = bufIndex;
+	fillEmptyBuffers();
+}
+
+int BufferManager::createWriteBuffer(const string& data, int bufIndex, int internalBufferIdx)
+{
+	buffers[bufIndex++] = new WriteBufferInfo(internalBufferIdx, data);
+	return bufIndex;
+}
+
+int BufferManager::createEraseBufferAndPassedWriteBuffer(int eraseStartLBA, int eraseCount, int bufIndex, std::vector<int>& writeLBAs)
+{
+	// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.	
+	buffers[bufIndex++] = new EraseBufferInfo(eraseStartLBA, eraseCount);
+	for (int writeLBA : writeLBAs) {
+		string data = internalBuffers[writeLBA].data;
+		buffers[bufIndex++] = new WriteBufferInfo(writeLBA, data);
+	}
+	return bufIndex;
+}
+
+vector<string> BufferManager::getOldFileNames()
+{
+	vector<string> oldNames;
+	for (int i = 0; i < BUFFER_SIZE; i++) {
+		oldNames.push_back(buffers[i]->getFileName(i));
+	}
+	return oldNames;
+}
+
+void BufferManager::fillEmptyBuffers()
+{
+	for (int bufIndex = getUsedBufferCount(); bufIndex < BUFFER_SIZE; bufIndex++) {
+		buffers[bufIndex] = new EmptyBufferInfo();
+	}
+}
+
+void BufferManager::writeAllBufferFiles(std::vector<std::string>& oldNames)
 {
 	for (int i = 0; i < BUFFER_SIZE; i++) {
 		const string& new_name = buffers[i]->getFileName(i);
-		const string& old_name = old_names[i];
+		const string& old_name = oldNames[i];
 		writeBufferFile(old_name, new_name);
 	}
 }
 
 void BufferManager::updateNandData(std::vector<std::string>& outData)
 {
-	for (int index = 0; index < 100; index++) {
-		if (internalBuffers[index].cmd == INVALID_VALUE) continue;
+	for (int index = 0; index <= MAX_LBA; index++) {
+		if (internalBuffers[index].cmd == BUFFER_EMPTY) continue;
 		outData[index] = internalBuffers[index].data;
 	}
 }
@@ -271,7 +290,7 @@ void BufferManager::updateNandData(std::vector<std::string>& outData)
 void BufferManager::flushInternalBuffers()
 {
 	for (int index = 0; index <= MAX_LBA; index++) {
-		internalBuffers[index].cmd = INVALID_VALUE;
+		internalBuffers[index].cmd = BUFFER_EMPTY;
 		internalBuffers[index].data = "";
 	}
 }

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -4,6 +4,45 @@
 #include <sstream>
 #include <iomanip>
 
+vector<InternalBufferInfo> WriteBufferInfo::makeInternalBufferInfos() {
+	vector<InternalBufferInfo> ret;
+	ret.push_back({ CMD_WRITE ,written_data });
+	return ret;
+}
+
+vector<InternalBufferInfo> EraseBufferInfo::makeInternalBufferInfos() {
+	vector<InternalBufferInfo> ret;
+	for (int count = 0; count < size; count++) {
+		ret.push_back({ CMD_ERASE ,NAND_DATA_EMPTY });
+	}
+	return ret;
+}
+
+vector<InternalBufferInfo> EmptyBufferInfo::makeInternalBufferInfos() {
+	vector<InternalBufferInfo> ret;
+	ret.push_back({ INVALID_VALUE , ""});
+	return ret;
+}
+
+string WriteBufferInfo::getFileName(int buf_idx) {
+	std::ostringstream oss;
+	oss << buf_idx + 1 << "_W_" << lba << "_" << written_data;
+	return oss.str();
+}
+
+string EraseBufferInfo::getFileName(int buf_idx) {
+	std::ostringstream oss;
+	oss << buf_idx + 1 << "_E_" << lba << "_" << size;
+	return oss.str();
+}
+
+string EmptyBufferInfo::getFileName(int buf_idx) {
+	std::ostringstream oss;
+	oss << buf_idx + 1 << "_empty";
+	return oss.str();
+}
+
+
 void BufferManager::init() {
 	fileHandler->createDirectory(BUFFER_DIR_NAME);
 	
@@ -54,33 +93,12 @@ void BufferManager::updateBufferState(int buf_idx)
 void BufferManager::updateInternalBufferState()
 {
 	for (int buf_idx = 0; buf_idx < BUFFER_SIZE; buf_idx++) {
-		if (buffers[buf_idx].cmd == CMD_WRITE) {
-			int lba = buffers[buf_idx].lba;
-			const string& data = buffers[buf_idx].written_data;
-			fillInternalBufferWrite(lba, data);
+		vector<InternalBufferInfo> internalBufferInfos = buffers[buf_idx]->makeInternalBufferInfos();
+		int lba = buffers[buf_idx]->lba;
+		for (int i = 0; i < internalBufferInfos.size(); i++) {
+			internalBuffers[lba + i] = internalBufferInfos[i];
 		}
-		else if (buffers[buf_idx].cmd == CMD_ERASE) {
-			int lba = buffers[buf_idx].lba;
-			int size = buffers[buf_idx].erase_size;
-			fillInternalBufferErase(lba, size);
-		}
-
-		if (buffers[buf_idx].cmd == INVALID_VALUE) break;
 	}
-}
-
-void BufferManager::fillInternalBufferErase(int lba, int size)
-{
-	for (int count = 0; count < size; count++) {
-		internalBuffers[lba + count].cmd = CMD_ERASE;
-		internalBuffers[lba + count].data = NAND_DATA_EMPTY;
-	}
-}
-
-void BufferManager::fillInternalBufferWrite(int lba, const string& data)
-{
-	internalBuffers[lba].cmd = CMD_WRITE;
-	internalBuffers[lba].data = data;
 }
 
 CMD_TYPE BufferManager::getBufferTypeFromFilenames(const string& fname) {
@@ -122,11 +140,8 @@ void BufferManager::parseEmptyBufferByFileName(int buf_idx, const string& fname)
 
 void BufferManager::setEmptyBufferInfo(int buf_idx)
 {
-	setBufferInfo(buf_idx,
-		INVALID_VALUE,
-		INVALID_VALUE,
-		"",
-		INVALID_VALUE);
+	if (buf_idx < 0 || buf_idx >= BUFFER_SIZE) throw std::exception("invalid buffer_num.");
+	buffers[buf_idx] = new EmptyBufferInfo();
 }
 
 void BufferManager::parseEraseBufferByFileName(int buf_idx, const string& fname)
@@ -141,11 +156,8 @@ void BufferManager::parseEraseBufferByFileName(int buf_idx, const string& fname)
 
 void BufferManager::setEraseBufferInfo(int buf_idx, int lba, int size)
 {
-	setBufferInfo(buf_idx,
-		CMD_ERASE,
-		lba,
-		""/*data*/,
-		size);
+	if (buf_idx < 0 || buf_idx >= BUFFER_SIZE) throw std::exception("invalid buffer_num.");
+	buffers[buf_idx] = new EraseBufferInfo(lba, size);
 }
 
 void BufferManager::parseWriteBufferByFileName(int buf_idx, const string& fname)
@@ -155,31 +167,15 @@ void BufferManager::parseWriteBufferByFileName(int buf_idx, const string& fname)
 	std::regex_search(fname, m, writeRegex);
 	int lba = std::atoi(m.str(1).c_str())/*LBA*/;
 	const string& written_data = m.str(2)/*data*/;
+	
 	setWriteBufferInfo(buf_idx, lba, written_data);
 }
 
 void BufferManager::setWriteBufferInfo(int buf_idx, int lba, const std::string& written_data)
 {
-	setBufferInfo(buf_idx,
-		CMD_WRITE,
-		lba,
-		written_data/*data*/,
-		INVALID_VALUE/*erase size*/);
-}
-
-void BufferManager::setBufferInfo(int buf_idx,
-	CMD_TYPE cmd,
-	int lba,
-	string written_data,
-	int size)
-{
 	if (buf_idx < 0 || buf_idx >= BUFFER_SIZE) throw std::exception("invalid buffer_num.");
-	buffers[buf_idx].cmd = cmd;
-	buffers[buf_idx].lba = lba;
-	buffers[buf_idx].written_data = written_data;
-	buffers[buf_idx].erase_size = size;
+	buffers[buf_idx] = new WriteBufferInfo(lba, written_data);
 }
-
 bool BufferManager::isBufferFull() {
 	return getUsedBufferCount() == BUFFER_SIZE;
 }
@@ -251,42 +247,28 @@ void BufferManager::updateBuffer() {
 	}
 }
 
-string BufferInfo::getFileName(int buf_idx) {
-	std::ostringstream oss;
-	if (cmd == INVALID_VALUE) {
-		oss << buf_idx + 1 << "_empty";
-	}
-	else if (cmd == CMD_WRITE) {
-		oss << buf_idx + 1 << "_W_" << lba << "_" << written_data;
-	}
-	else if (cmd == CMD_ERASE) {
-		oss << buf_idx + 1 << "_E_" << lba << "_" << erase_size;
-	}
-	return oss.str();
-}
-
 void BufferManager::fillEmptyBufferInfo(int buf_idx)
 {
-	string old_name = buffers[buf_idx].getFileName(buf_idx);
+	string old_name = buffers[buf_idx]->getFileName(buf_idx);
 	setEmptyBufferInfo(buf_idx);
-	string new_name = buffers[buf_idx].getFileName(buf_idx);
+	string new_name = buffers[buf_idx]->getFileName(buf_idx);
 	writeBufferFile(old_name, new_name);
 }
 
 void BufferManager::fillWriteBufferInfo(int write_lba, int buf_idx)
 {
-	string old_name = buffers[buf_idx].getFileName(buf_idx);
+	string old_name = buffers[buf_idx]->getFileName(buf_idx);
 	string data = internalBuffers[write_lba].data;
 	setWriteBufferInfo(buf_idx, write_lba, data);
-	string new_name = buffers[buf_idx].getFileName(buf_idx);
+	string new_name = buffers[buf_idx]->getFileName(buf_idx);
 	writeBufferFile(old_name, new_name);
 }
 
 void BufferManager::fillEraseBufferInfo(int buf_idx, int erase_start, int erase_count)
 {
-	string old_name = buffers[buf_idx].getFileName(buf_idx);
+	string old_name = buffers[buf_idx]->getFileName(buf_idx);
 	setEraseBufferInfo(buf_idx, erase_start, erase_count);
-	string new_name = buffers[buf_idx].getFileName(buf_idx);
+	string new_name = buffers[buf_idx]->getFileName(buf_idx);
 	writeBufferFile(old_name, new_name);
 }
 

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -139,7 +139,7 @@ void BufferManager::updateBufferByInternalBuffer() {
 	bool meetErase = false;
 	vector<int> writeLBAs;
 	vector<string> old_names = getOldFileNames();
-	int buf_idx = MIN_LBA;
+	int bufIndex = MIN_LBA;
 	for (int internalBufferIdx = MIN_LBA; internalBufferIdx <= MAX_LBA; internalBufferIdx++) {
 		InternalBufferInfo& internalBuffer = internalBuffers[internalBufferIdx];
 		if (meetErase == false) {
@@ -148,8 +148,9 @@ void BufferManager::updateBufferByInternalBuffer() {
 				eraseStartLBA = internalBufferIdx;
 				writeLBAs.clear();
 
-				if(isLastLBA(internalBufferIdx))
-					fillEraseBufferInfo(buf_idx, eraseStartLBA, 1);
+				if (isLastLBA(internalBufferIdx)) {
+					bufIndex = createEraseBufferAndPassedWriteBuffer(eraseStartLBA, 1, bufIndex, writeLBAs);
+				}
 			}
 			else if (internalBuffer.cmd == CMD_WRITE) {
 				bufIndex = createWriteBuffer(bufIndex, internalBufferIdx, internalBuffer.data);
@@ -159,17 +160,17 @@ void BufferManager::updateBufferByInternalBuffer() {
 			if (internalBuffer.cmd == CMD_WRITE) {
 				writeLBAs.push_back(internalBufferIdx);
 			}
-
-			if (meetErase == true && (internalBufferIdx == MAX_LBA || internalBufferIdx - eraseStartLBA + 1 == MAX_ERASE_COUNT)) {
-				int eraseCount = internalBufferIdx - eraseStartLBA + 1;
-				bufIndex = createEraseBufferAndPassedWriteBuffer(eraseStartLBA, eraseCount, bufIndex, writeLBAs);
-				meetErase = false;
-			}
 			if (internalBuffer.cmd == BUFFER_EMPTY) {
 				int eraseCount = internalBufferIdx - eraseStartLBA;
 				bufIndex = createEraseBufferAndPassedWriteBuffer(eraseStartLBA, eraseCount, bufIndex, writeLBAs);
 				meetErase = false;
 			}
+			if (meetErase == true && (internalBufferIdx == MAX_LBA || internalBufferIdx - eraseStartLBA + 1 == MAX_ERASE_COUNT)) {
+				int eraseCount = internalBufferIdx - eraseStartLBA + 1;
+				bufIndex = createEraseBufferAndPassedWriteBuffer(eraseStartLBA, eraseCount, bufIndex, writeLBAs);
+				meetErase = false;
+			}
+
 		}
 	}
 	valid_buf_cnt = bufIndex;

--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -3,7 +3,6 @@
 #include <string>
 #include <sstream>
 #include <iomanip>
-#include <iostream>
 
 void WriteBufferInfo::updateInternalBufferInfos(vector<InternalBufferInfo> internalBufferInfos) {
 	internalBufferInfos[lba].cmd = CMD_WRITE;
@@ -25,7 +24,6 @@ string WriteBufferInfo::getFileName(int buf_idx) {
 	std::ostringstream oss;
 	oss << buf_idx + 1 << "_W_" << lba << "_" << written_data;
 	string fileName = oss.str();
-	std::cout << fileName;
 	return fileName;
 }
 
@@ -33,7 +31,6 @@ string EraseBufferInfo::getFileName(int buf_idx) {
 	std::ostringstream oss;
 	oss << buf_idx + 1 << "_E_" << lba << "_" << size;
 	string fileName = oss.str();
-	std::cout << fileName;
 	return fileName;
 }
 
@@ -41,7 +38,6 @@ string EmptyBufferInfo::getFileName(int buf_idx) {
 	std::ostringstream oss;
 	oss << buf_idx + 1 << "_empty";
 	string fileName = oss.str();
-	std::cout << fileName;
 	return fileName;
 }
 

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -9,6 +9,7 @@
 using std::string;
 using std::vector;
 
+
 struct InternalBufferInfo {
 	CMD_TYPE cmd;
 	string data;
@@ -17,34 +18,35 @@ struct InternalBufferInfo {
 class BufferInfo
 {
 protected:
-	BufferInfo(int lba) : lba{ lba } {}
 public:
-	int lba;
+
 	virtual string getFileName(int buf_idx) = 0;
-	virtual vector<InternalBufferInfo> makeInternalBufferInfos() = 0;
+	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>) = 0;
 };
 
 class WriteBufferInfo : public BufferInfo {
 public:
-	WriteBufferInfo(int lba, const string& data) : BufferInfo(lba), written_data(data) {}
+	WriteBufferInfo(int lba, const string& data) :lba{ lba }, written_data(data) {}
 	string getFileName(int buf_idx) override;
-	vector<InternalBufferInfo> makeInternalBufferInfos() override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
 	string written_data;
+	int lba;
 };
 
 class EraseBufferInfo : public BufferInfo {
 public:
-	EraseBufferInfo(int lba, int size) : BufferInfo(lba), size(size) {}
+	EraseBufferInfo(int lba, int size) : lba{ lba }, size(size) {}
 	string getFileName(int buf_idx) override;
-	vector<InternalBufferInfo> makeInternalBufferInfos() override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
 	int size;
+	int lba;
 };
 
 class EmptyBufferInfo : public BufferInfo {
 public:
-	EmptyBufferInfo(int lba = INVALID_VALUE): BufferInfo(lba){}
+	EmptyBufferInfo(){}
 	string getFileName(int buf_idx) override;
-	vector<InternalBufferInfo> makeInternalBufferInfos() override;
+	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
 };
 
 
@@ -128,7 +130,6 @@ private:
 	void updateBuffer();
 
 	void initInternalBuffers();
-	void fillInternalBufferEmpty(int index);
 	void fillEmptyBufferInfo(int buffer_idx);
 	void fillWriteBufferInfo(int write_lba, int buffer_idx);
 	void fillEraseBufferInfo(int buffer_idx, int erase_start, int erase_count);

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -10,7 +10,6 @@
 using std::string;
 using std::vector;
 
-
 struct InternalBufferInfo {
 	CMD_TYPE cmd;
 	string data;
@@ -71,7 +70,7 @@ public:
 	BufferManager(NandFlashMemory* nandFlashMemory, FileHandler* fileHandler)
 		: nandFlashMemory{ nandFlashMemory }, fileHandler{ fileHandler } {
 
-		initInternalBuffers();
+		flushInternalBuffers();
 
 		for (int i = 0; i < BUFFER_SIZE; i++) {
 			buffers[i] = new EmptyBufferInfo();
@@ -110,36 +109,21 @@ private:
 	vector<InternalBufferInfo> internalBuffers{ 100 };
 	int valid_buf_cnt{ 0 };
 
-	// Buffer 파일 존재 여부를 반환합니다.
+	// init step
 	bool existBufferFile(int buf_idx);
-
-	// Buffer Empty 파일을 생성합니다.
-	void createBufferFile(int buf_idx);
-
-	// Buffer 파일의 Prefix 매크로 반환합니다.
+	void createEmptyBufferFile(int buf_idx);
 	string getBufferFilePrefix(int buf_idx);
-
-	// 버퍼 상태 업데이트
 	void updateBufferState(int buf_idx);
-
 	void updateInternalBufferState();
-
 	void fillBufferInfo(string fname, int buf_idx);
-
 	CMD_TYPE getBufferTypeFromFilenames(const string& fname);
-
-	// 버퍼가 5개가 가득 찬 경우 true를 리턴합니다.
-	bool isBufferFull();
-
-	//fileHandler에 새로 버퍼를 기록합니다.
-	void writeBufferFile(const string& old_name, const string& new_name);
-
 	void IncreaseBufferCnt();
 
+	bool isBufferFull();
+	void flushInternalBuffers();
+
+	void writeBufferFile(const string& old_name, const string& new_name);
 	void updateBuffer();
-
 	vector<string> getOldFileNames();
-
-	void initInternalBuffers();
 	inline bool isLastLBA(int lba) { return lba == MAX_LBA; }
 };

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -72,17 +72,23 @@ private:
 
 	void updateInternalBufferState();
 
-	void fillInternalBufferErase(int buffer_idx);
+	void fillInternalBufferErase(int lba, int size);
 
-	void fillInternalBufferWrite(int buffer_idx);
+	void fillInternalBufferWrite(int lba, const string& data);
 
 	void fillBufferInfo(string fname, int buf_idx);
 
-	void setEmptyBufferInfo(int buf_idx, const string& fname);
+	void parseEmptyBufferByFileName(int buf_idx, const string& fname);
 
-	void setEraseBufferInfo(int buf_idx, const string& fname);
+	void setEmptyBufferInfo(int buf_idx);
 
-	void setWriteBufferInfo(int buf_idx, const string& fname);
+	void parseEraseBufferByFileName(int buf_idx, const string& fname);
+
+	void setEraseBufferInfo(int buf_idx, int lba, int size);
+
+	void parseWriteBufferByFileName(int buf_idx, const string& fname);
+
+	void setWriteBufferInfo(int buf_idx, int lba, const std::string& written_data);
 
 	CMD_TYPE getBufferTypeFromFilenames(const string& fname);
 
@@ -98,13 +104,14 @@ private:
 	bool isBufferFull();
 
 	//fileHandler에 새로 버퍼를 기록합니다.
-	void writeBuffer(const string& old_name, const string& new_name);
+	void writeBufferFile(const string& old_name, const string& new_name);
 
 	void IncreaseBufferCnt();
 
 	void updateBuffer();
 
 	void initInternalBuffers();
+	void fillInternalBufferEmpty(int index);
 	void fillEmptyBufferInfo(int buffer_idx);
 	void fillWriteBufferInfo(int write_lba, int buffer_idx);
 	void fillEraseBufferInfo(int buffer_idx, int erase_start, int erase_count);

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -20,7 +20,7 @@ class BufferInfo
 protected:
 public:
 
-	virtual string getFileName(int buf_idx) = 0;
+	virtual string getFileName(int bufIndex) = 0;
 	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>) = 0;
 };
 
@@ -34,7 +34,7 @@ public:
 		lba = std::atoi(m.str(1).c_str());
 		written_data = m.str(2);
 	}
-	string getFileName(int buf_idx) override;
+	string getFileName(int bufIndex) override;
 	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
 	string written_data;
 	int lba;
@@ -50,7 +50,7 @@ public:
 		lba = std::atoi(m.str(1).c_str())/*LBA*/;
 		size = std::atoi(m.str(2).c_str())/*erase size*/;
 	}
-	string getFileName(int buf_idx) override;
+	string getFileName(int bufIndex) override;
 	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
 	int size;
 	int lba;
@@ -59,7 +59,7 @@ public:
 class EmptyBufferInfo : public BufferInfo {
 public:
 	EmptyBufferInfo(){}
-	string getFileName(int buf_idx) override;
+	string getFileName(int bufIndex) override;
 	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
 };
 
@@ -90,15 +90,9 @@ public:
 	// erase 커맨드에 대한 내용을 버퍼에 씁니다.
 	// 만일 버퍼가 가득차면 flush 수행 후에 버퍼에 씁니다.
 	void addEraseCommand(int lba, int count);
-
 	// 모든 버퍼의 내용을 nand에 기록합니다.
 	void flush();
 
-	void fillEmptyBuffers();
-
-	void writeAllBufferFiles(std::vector<std::string>& old_names);
-
-	void updateNandData(std::vector<std::string>& datas);
 
 	// empty가 아닌 버퍼의 개수를 리턴합니다.
 	int getUsedBufferCount();
@@ -110,12 +104,12 @@ private:
 	int valid_buf_cnt{ 0 };
 
 	// init step
-	bool existBufferFile(int buf_idx);
-	void createEmptyBufferFile(int buf_idx);
-	string getBufferFilePrefix(int buf_idx);
-	void updateBufferState(int buf_idx);
+	bool existBufferFile(int bufIndex);
+	void createEmptyBufferFile(int bufIndex);
+	string getBufferFilePrefix(int bufIndex);
+	void updateBufferState(int bufIndex);
 	void updateInternalBufferState();
-	void fillBufferInfo(string fname, int buf_idx);
+	void fillBufferInfo(string fname, int bufIndex);
 	CMD_TYPE getBufferTypeFromFilenames(const string& fname);
 	void IncreaseBufferCnt();
 
@@ -123,7 +117,16 @@ private:
 	void flushInternalBuffers();
 
 	void writeBufferFile(const string& old_name, const string& new_name);
-	void updateBuffer();
+	void updateBufferByInternalBuffer();
+	int createWriteBuffer(const string& internalBuffer, int bufIndex, int internalBufferIdx);
+	int createEraseBufferAndPassedWriteBuffer(int eraseStartLBA, int eraseCount, int bufIndex, std::vector<int>& writeLBAs);
 	vector<string> getOldFileNames();
 	inline bool isLastLBA(int lba) { return lba == MAX_LBA; }
+	void setInternalBufferWrite(int lba, const std::string& data);
+	void SetInternalBufferErase(int lba, int count);
+	void WriteUpdatedBufferFiles();
+	void writeEmptyBufferFiles();
+	void fillEmptyBuffers();
+	void writeAllBufferFiles(std::vector<std::string>& old_names);
+	void updateNandData(std::vector<std::string>& datas);
 };

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -56,7 +56,6 @@ private:
 	void updateBufferState(int bufIndex);
 	void updateInternalBufferState();
 	void fillBufferInfo(string fname, int bufIndex);
-	CMD_TYPE getBufferTypeFromFilenames(const string& fname);
 	void IncreaseBufferCnt();
 
 	bool isBufferFull();
@@ -64,7 +63,7 @@ private:
 
 	void writeBufferFile(const string& old_name, const string& new_name);
 	void updateBufferByInternalBuffer();
-	int createWriteBuffer(const string& internalBuffer, int bufIndex, int internalBufferIdx);
+	int createWriteBuffer(int bufIndex, int LBA, const string& data);
 	int createEraseBufferAndPassedWriteBuffer(int eraseStartLBA, int eraseCount, int bufIndex, std::vector<int>& writeLBAs);
 	vector<string> getOldFileNames();
 	inline bool isLastLBA(int lba) { return lba == MAX_LBA; }

--- a/SSD/buffer_manager.h
+++ b/SSD/buffer_manager.h
@@ -1,68 +1,14 @@
 ﻿#pragma once
 #include <string>
 #include <vector>
-#include <regex>
 #include <cstring>
 #include <Windows.h>
 #include <stdexcept>
+#include "buffer_info.h"
 #include "nand_flash_memory_impl.h"
 
 using std::string;
 using std::vector;
-
-struct InternalBufferInfo {
-	CMD_TYPE cmd;
-	string data;
-};
-
-class BufferInfo
-{
-protected:
-public:
-
-	virtual string getFileName(int bufIndex) = 0;
-	virtual void updateInternalBufferInfos(vector<InternalBufferInfo>) = 0;
-};
-
-class WriteBufferInfo : public BufferInfo {
-public:
-	static const std::regex fileNameRegex;
-	WriteBufferInfo(int lba, const string& data) :lba{ lba }, written_data(data) {}
-	WriteBufferInfo(const string& fname) {
-		std::smatch m;
-		std::regex_search(fname, m, WriteBufferInfo::fileNameRegex);
-		lba = std::atoi(m.str(1).c_str());
-		written_data = m.str(2);
-	}
-	string getFileName(int bufIndex) override;
-	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
-	string written_data;
-	int lba;
-};
-
-class EraseBufferInfo : public BufferInfo {
-public:
-	static const std::regex fileNameRegex;
-	EraseBufferInfo(int lba, int size) : lba{ lba }, size(size) {}
-	EraseBufferInfo(const string& fname) {
-		std::smatch m;
-		std::regex_search(fname, m, EraseBufferInfo::fileNameRegex);
-		lba = std::atoi(m.str(1).c_str())/*LBA*/;
-		size = std::atoi(m.str(2).c_str())/*erase size*/;
-	}
-	string getFileName(int bufIndex) override;
-	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
-	int size;
-	int lba;
-};
-
-class EmptyBufferInfo : public BufferInfo {
-public:
-	EmptyBufferInfo(){}
-	string getFileName(int bufIndex) override;
-	void updateInternalBufferInfos(vector<InternalBufferInfo>) override;
-};
-
 
 class BufferManager {
 public:

--- a/SSD/buffer_manager_test.cpp
+++ b/SSD/buffer_manager_test.cpp
@@ -192,6 +192,7 @@ TEST_F(BufferManagerFixture, FileNameTest2) {
 	manager.addWriteCommand(10, "0x11111111");
 }
 
+
 TEST_F(BufferManagerFixture, InitEraseAndEraseTest) {
 	EXPECT_CALL(fileHandler, isFileExistByMatchLength(_, _, _))
 		.WillOnce(Return(false))
@@ -220,6 +221,20 @@ TEST_F(BufferManagerFixture, InitWriteAndEraseTest) {
 	manager.addEraseCommand(0, 5);
 }
 
+TEST_F(BufferManagerFixture, InitWriteAndEraseTest2) {
+	EXPECT_CALL(fileHandler, isFileExistByMatchLength(_, _, _))
+		.WillOnce(Return(false))
+		.WillOnce(Return(true))
+		.WillRepeatedly(Return(false));
+	EXPECT_CALL(fileHandler, getFileUsingPrefix)
+		.WillOnce(Return(vector<string>{"1_W_0_0x11112222"}));
+
+	EXPECT_CALL(fileHandler, rename("buffer\\2_empty", "buffer\\2_W_1_0x22223333"))
+		.Times(1);
+	manager.init();
+
+	manager.addWriteCommand(1, "0x22223333");
+}
 
 TEST_F(BufferManagerFixture, MAXLBA_TEST) {
 	manager.addEraseCommand(97, 3);

--- a/SSD/global_config.h
+++ b/SSD/global_config.h
@@ -3,6 +3,7 @@
 // SSD
 #define MAX_LBA 99
 #define MIN_LBA 0
+#define MAX_ERASE_COUNT 10
 #define CMD_INVALID	0xFFFF
 #define CMD_READ	1
 #define CMD_WRITE	2

--- a/SSD/global_config.h
+++ b/SSD/global_config.h
@@ -35,5 +35,6 @@
 #define BUFFER_DIR_NAME	"buffer"
 #define BUFFER_SIZE 5
 #define BUFFER_NAME_EMPTY	"empty"
+#define BUFFER_EMPTY 0xFFFF
 
 typedef int CMD_TYPE;

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -1,6 +1,7 @@
 ﻿#include "ssd.h"
 #include "buffer_manager.h"
 #include <stdexcept>
+#include <iostream>
 #include "ssd_command.h"
 
 SSD::SSD(FileHandler* fileHandler) {
@@ -36,6 +37,7 @@ void SSD::run(int argc, const char* argv[])
 	}
 	catch (std::exception e) {
 		result = "ERROR";
+		std::cout << e.what()<<std::endl;
 	}
 	outputHandler->output(result);
 }

--- a/SSD/ssd.cpp
+++ b/SSD/ssd.cpp
@@ -1,7 +1,6 @@
 ﻿#include "ssd.h"
 #include "buffer_manager.h"
 #include <stdexcept>
-#include <iostream>
 #include "ssd_command.h"
 
 SSD::SSD(FileHandler* fileHandler) {
@@ -37,7 +36,6 @@ void SSD::run(int argc, const char* argv[])
 	}
 	catch (std::exception e) {
 		result = "ERROR";
-		std::cout << e.what()<<std::endl;
 	}
 	outputHandler->output(result);
 }


### PR DESCRIPTION
패치 내용
- 
패치 세부 내용
1. bufferManager 리팩토링입니다.
2. bufferManager 에서 buffer Info 부분을 EraseBufferInfo / WriteBufferInfo / EmptyBufferInfo 로 분리하였습니다.
4. bufferInfoFactory를 추가하였고, bufferManager 곳곳의 BufferInfo 생성 부분을 Factory가 담당하게 했습니다. 

아직 함수 단위의 리팩토링에 좀더 고민하고 있는 부분이 있습니다.
한번 PR 올리고 의견 받아서 리팩토링 방향을 좀더 생각해보겠습니다.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
