### PR TITLE
[Fix] Size 9 Erase에 대한 Buffer Logic 탈 경우, Size 10 Erase Cmd도 이어서 추가되는 버그 수정

### DIFF
--- a/SSD/buffer_manager.cpp
+++ b/SSD/buffer_manager.cpp
@@ -188,11 +188,7 @@ void BufferManager::updateBuffer() {
 			}
 		}
 		else {
-			if (internalBuffer.cmd == CMD_WRITE) {
-				// erase 사이에 등장한 write는 따로 기록해 둡니다.
-				write_lbas.push_back(internalBufferIdx);
-			}
-			else if (internalBuffer.cmd == INVALID_VALUE) {
+			if (internalBuffer.cmd == INVALID_VALUE) {
 				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
 				int erase_count = internalBufferIdx - eraseStartLBA;
 				fillEraseBufferInfo(buf_idx, eraseStartLBA, erase_count);
@@ -203,8 +199,11 @@ void BufferManager::updateBuffer() {
 				}
 				meetErase = false;
 			}
-
-			if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
+			else if (internalBufferIdx == 99 || internalBufferIdx - eraseStartLBA == 9) {
+				if (internalBuffer.cmd == CMD_WRITE) {
+					// erase 사이에 등장한 write는 따로 기록해 둡니다.
+					write_lbas.push_back(internalBufferIdx);
+				}
 				// erase 가 끝나면, eraseBuffer를 기록하고, 그 사이에 지나친 write 들도 기록합니다.
 				int erase_count = internalBufferIdx - eraseStartLBA + 1;
 				fillEraseBufferInfo(buf_idx, eraseStartLBA, erase_count);


### PR DESCRIPTION
패치 내용
- Size 9 Erase에 대한 Buffer Logic 탈 경우, Size 10 Erase Cmd도 이어서 추가되는 버그 수정

패치 세부 내용
1. Buffer Logic에서 Buffer에 LBA 최대 또는 Erase Size 10개로 Erase Command를 버퍼에 쓸 경우, meetErase를 확인하는 조건 추가


이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
