### PR TITLE
[FIX] erase range error

### DIFF
--- a/TestShell/erase_command.cpp
+++ b/TestShell/erase_command.cpp
@@ -38,7 +38,7 @@ void EraseCommand::printResult(const string& result, const string& lba) const
 bool EraseCommand::checkLbaRange(int startLBAIndex, int range) const
 {
 	if (isValidLba(startLBAIndex) == false) { return false; }
-	if (isValidLba(range + startLBAIndex) == false) { return false; }
+	if (isValidLba(range + startLBAIndex -1) == false) { return false; }
 
 	return true;
 }


### PR DESCRIPTION
패치 내용
- erase command 에서 99 를 invalid로 취급했던 것을 수정하였습니다.
패치 세부 내용
1.
2.
3.

이 부분은 중점적으로 봐주세요
-

Check lists
- [x] Ctrl + K + D 로 포매팅 확인
- [x] Build 확인 (master branch 기준)
- [x] Unit Test 100% 통과 확인 (master branch 기준)
- [x] 이상한 파일이 들어가지 않았는지 확인
