### PR TITLE
SSD compile 중 size_t 를 int로 형변환되어 발생한 warning 제거

### DIFF
--- a/SSD/file_handler.h
+++ b/SSD/file_handler.h
@@ -23,7 +23,7 @@ public:
 	virtual void rename(const string& old_name, const string& new_name) const = 0;
 	
 	// Directory에서 file 이름의 len 만큼만 비교하여 같은 파일이 존재하는지 여부 반환
-	virtual bool isFileExistByMatchLength(const string& dir_path, const string& file_name, int len) = 0;
+	virtual bool isFileExistByMatchLength(const string& dir_path, const string& file_name, size_t len) = 0;
 	
 	// Path에 있는 파일들 중에서 prefix가 포함되어 있는 파일명 반환
 	virtual vector<string> getFileUsingPrefix(const string& path, const string& prefix) = 0;

--- a/SSD/file_handler_impl.cpp
+++ b/SSD/file_handler_impl.cpp
@@ -66,7 +66,7 @@ void FileHandlerImpl::rename(const string& old_name, const string& new_name) con
 	}
 }
 
-bool FileHandlerImpl::isFileExistByMatchLength(const string& dir_path, const string& file_name, int len)
+bool FileHandlerImpl::isFileExistByMatchLength(const string& dir_path, const string& file_name, size_t len)
 {
 	WIN32_FIND_DATAA findFileData;
 	HANDLE hFind = FindFirstFileA(dir_path.c_str(), &findFileData);

--- a/SSD/file_handler_impl.h
+++ b/SSD/file_handler_impl.h
@@ -30,7 +30,7 @@ public:
 	void rename(const string& old_name, const string& new_name) const override;
 
 	// Directory에서 file 이름의 len 만큼만 비교하여 같은 파일이 존재하는지 여부 반환
-	bool isFileExistByMatchLength(const string& dir_path, const string& file_name, int len) override;
+	bool isFileExistByMatchLength(const string& dir_path, const string& file_name, size_t len) override;
 
 	// Path에 있는 파일들 중에서 prefix가 포함되어 있는 파일명 반환
 	vector<string> getFileUsingPrefix(const string& path, const string& prefix) override;

--- a/SSD/file_handler_mock.h
+++ b/SSD/file_handler_mock.h
@@ -9,6 +9,6 @@ public:
 	MOCK_METHOD(char*, readFile, (const string&), (override));
 	MOCK_METHOD(void, writeData, (const string&, const string&), (override));
 	MOCK_METHOD(void, rename, (const string&, const string&), (override, const));
-	MOCK_METHOD(bool, isFileExistByMatchLength, (const string&, const string&, int), (override));
+	MOCK_METHOD(bool, isFileExistByMatchLength, (const string&, const string&, size_t), (override));
 	MOCK_METHOD(vector<string>, getFileUsingPrefix, (const string&, const string&), (override));
 };


### PR DESCRIPTION
패치 내용
- SSD compile 중 size_t 를 int로 형변환되어 발생한 warning 제거
- 
패치 세부 내용
1. 함수 parameter를 int --> size_t로 변경

이 부분은 중점적으로 봐주세요
-

Check lists
- [X] Ctrl + K + D 로 포매팅 확인
- [X] Build 확인 (master branch 기준)
- [X] Unit Test 100% 통과 확인 (master branch 기준)
- [X] 이상한 파일이 들어가지 않았는지 확인

<img width="570" height="328" alt="image" src="https://github.com/user-attachments/assets/4ff57dc6-437d-4c4e-8bc9-569cb0d3512f" />

